### PR TITLE
Add quiz completion day-streak metric and profile UI

### DIFF
--- a/prisma/migrations/20260615025159_user_stats_streak/migration.sql
+++ b/prisma/migrations/20260615025159_user_stats_streak/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "UserStats" ADD COLUMN     "currentStreak" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "longestStreak" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,10 @@ model UserStats {
   totalCorrectAnswers    Int               @default(0)
   rank                   Int               @default(0)
   eloRating              Int               @default(1000)
+  // Consecutive days (within STREAK_WINDOW_DAYS gaps) on which the user has
+  // completed a quiz. Recomputed from UserStatsTrends after each completed quiz.
+  currentStreak          Int               @default(0)
+  longestStreak          Int               @default(0)
   updatedAt              DateTime          @updatedAt
   UserStatsTrends        UserStatsTrends[]
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,7 @@
 const defaultQuizSize = 10;
 const debug = false;
-export { defaultQuizSize, debug };
+// Maximum gap, in days, allowed between two quiz-completion days for the streak
+// to stay alive. 1 = a strict day-over-day streak; the most recent active day
+// must also be within this many days of today for the current streak to count.
+const STREAK_WINDOW_DAYS = 1;
+export { defaultQuizSize, debug, STREAK_WINDOW_DAYS };

--- a/src/lib/streak.test.ts
+++ b/src/lib/streak.test.ts
@@ -1,0 +1,79 @@
+import { computeStreaks } from './streak';
+import { expect, describe, it } from 'vitest';
+
+// Helper to build a UTC-midnight date from a YYYY-MM-DD string.
+const day = (iso: string) => new Date(`${iso}T00:00:00.000Z`);
+
+describe('computeStreaks', () => {
+  it('returns zero streaks when there is no activity', () => {
+    expect(computeStreaks([], 1, day('2026-06-14'))).toEqual({
+      currentStreak: 0,
+      longestStreak: 0
+    });
+  });
+
+  it('counts a single active day as a streak of 1', () => {
+    expect(computeStreaks([day('2026-06-14')], 1, day('2026-06-14'))).toEqual({
+      currentStreak: 1,
+      longestStreak: 1
+    });
+  });
+
+  it('counts consecutive days ending today', () => {
+    const dates = [day('2026-06-12'), day('2026-06-13'), day('2026-06-14')];
+    expect(computeStreaks(dates, 1, day('2026-06-14'))).toEqual({
+      currentStreak: 3,
+      longestStreak: 3
+    });
+  });
+
+  it('keeps the current streak alive when the latest day is yesterday', () => {
+    const dates = [day('2026-06-12'), day('2026-06-13')];
+    expect(computeStreaks(dates, 1, day('2026-06-14')).currentStreak).toBe(2);
+  });
+
+  it('resets the current streak when the gap to today exceeds the window', () => {
+    const dates = [day('2026-06-10'), day('2026-06-11')];
+    const result = computeStreaks(dates, 1, day('2026-06-14'));
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(2);
+  });
+
+  it('breaks the streak on a gap larger than the window', () => {
+    const dates = [day('2026-06-10'), day('2026-06-13'), day('2026-06-14')];
+    expect(computeStreaks(dates, 1, day('2026-06-14'))).toEqual({
+      currentStreak: 2,
+      longestStreak: 2
+    });
+  });
+
+  it('dedupes multiple quizzes on the same day', () => {
+    const dates = [day('2026-06-14'), day('2026-06-14'), day('2026-06-13')];
+    expect(computeStreaks(dates, 1, day('2026-06-14'))).toEqual({
+      currentStreak: 2,
+      longestStreak: 2
+    });
+  });
+
+  it('honours a larger window allowing gaps between active days', () => {
+    const dates = [day('2026-06-10'), day('2026-06-12'), day('2026-06-14')];
+    expect(computeStreaks(dates, 2, day('2026-06-14'))).toEqual({
+      currentStreak: 3,
+      longestStreak: 3
+    });
+  });
+
+  it('reports the longest streak even when it is in the past', () => {
+    const dates = [
+      day('2026-06-01'),
+      day('2026-06-02'),
+      day('2026-06-03'),
+      day('2026-06-13'),
+      day('2026-06-14')
+    ];
+    expect(computeStreaks(dates, 1, day('2026-06-14'))).toEqual({
+      currentStreak: 2,
+      longestStreak: 3
+    });
+  });
+});

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,0 +1,59 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Convert a UTC-midnight Date into an integer day index so days can be compared
+ * and subtracted without time-of-day or DST noise.
+ */
+const toDayNumber = (date: Date): number => Math.floor(date.getTime() / MS_PER_DAY);
+
+export interface Streaks {
+  currentStreak: number;
+  longestStreak: number;
+}
+
+/**
+ * Compute the user's current and longest streaks from the set of days on which
+ * they completed at least one quiz.
+ *
+ * A streak is a run of active days where the gap between consecutive active days
+ * is no greater than `windowDays`. The current streak is only counted when the
+ * most recent active day is itself within `windowDays` of `today` (otherwise the
+ * streak has lapsed and the current streak is 0).
+ *
+ * @param activeDates Days (UTC midnight) the user completed a quiz. Order/dupes don't matter.
+ * @param windowDays  Max allowed gap between active days (and from today). >= 1.
+ * @param today       Reference "now" as a UTC-midnight Date.
+ */
+export function computeStreaks(activeDates: Date[], windowDays: number, today: Date): Streaks {
+  if (activeDates.length === 0) {
+    return { currentStreak: 0, longestStreak: 0 };
+  }
+
+  const window = Math.max(1, Math.floor(windowDays));
+
+  // Dedupe to day granularity and sort ascending.
+  const days = [...new Set(activeDates.map(toDayNumber))].sort((a, b) => a - b);
+
+  // Longest streak: walk forward, extending the run while the gap stays within
+  // the window, otherwise start a new run.
+  let longestStreak = 1;
+  let run = 1;
+  for (let i = 1; i < days.length; i++) {
+    run = days[i] - days[i - 1] <= window ? run + 1 : 1;
+    if (run > longestStreak) longestStreak = run;
+  }
+
+  // Current streak: only alive if the latest active day is recent enough.
+  const todayNumber = toDayNumber(today);
+  const latest = days[days.length - 1];
+  let currentStreak = 0;
+  if (todayNumber - latest <= window) {
+    currentStreak = 1;
+    for (let i = days.length - 1; i > 0; i--) {
+      if (days[i] - days[i - 1] <= window) currentStreak++;
+      else break;
+    }
+  }
+
+  return { currentStreak, longestStreak: Math.max(longestStreak, currentStreak) };
+}

--- a/src/routes/api/quiz/questions/+server.ts
+++ b/src/routes/api/quiz/questions/+server.ts
@@ -3,6 +3,8 @@ import { json } from '@sveltejs/kit';
 import { updateEloRankings } from '$lib/eloRating';
 import type { QuizDataWithoutQuestions } from '$lib/types';
 import { getUTCDate } from '$lib/datetime/date';
+import { computeStreaks } from '$lib/streak';
+import { STREAK_WINDOW_DAYS } from '$lib/constants';
 
 export const POST = async ({ request }) => {
   const { quizId, questionId, userAnswer } = await request.json();
@@ -173,5 +175,21 @@ async function postQuizTasksNonBlocking(quizWithQuestions: QuizDataWithoutQuesti
       totalQuestionsAnswered: quizWithQuestions.quizQuestions.length,
       totalCorrectAnswers: correctAnswers
     }
+  });
+
+  // Recompute the streak from the per-day trend records (one row per active
+  // day) so the stored value is always consistent, even if a day was missed.
+  const activeDays = await prisma.userStatsTrends.findMany({
+    where: { userStatsId: userStats.id },
+    select: { date: true }
+  });
+  const { currentStreak, longestStreak } = computeStreaks(
+    activeDays.map((d) => d.date),
+    STREAK_WINDOW_DAYS,
+    dateUTC
+  );
+  await prisma.userStats.update({
+    where: { id: userStats.id },
+    data: { currentStreak, longestStreak }
   });
 }

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -42,6 +42,8 @@
         ? 0
         : userStats.totalCorrectAnswers / userStats.totalQuestionsAnswered}
       rank={userStats.rank}
+      currentStreak={userStats.currentStreak}
+      longestStreak={userStats.longestStreak}
     />
   </div>
 
@@ -115,7 +117,6 @@
     <h2>Achievements</h2>
     <!--TODO Number of quizzes completed -->
     <!--TODO Days of participation -->
-    <!--TODO Day streak -->
     <!--TODO Rank -->
   </section>
 
@@ -123,7 +124,6 @@
     <h2>Stats</h2>
     <!--TODO Number of quizzes completed -->
     <!--TODO Days of participation -->
-    <!--TODO Day streak -->
     <!--TODO Rank -->
     <!--TODO Time Map -->
     <!--TODO Rank, Question Difficulty, Speed over time -->

--- a/src/routes/profile/components/ProfileStats.svelte
+++ b/src/routes/profile/components/ProfileStats.svelte
@@ -5,9 +5,21 @@
     completedQuizzes: number;
     accuracy: number;
     rank: number;
+    currentStreak: number;
+    longestStreak: number;
   }
 
-  let { completedQuizzes = 0, accuracy = 0, rank = 0 }: Props = $props();
+  let {
+    completedQuizzes = 0,
+    accuracy = 0,
+    rank = 0,
+    currentStreak = 0,
+    longestStreak = 0
+  }: Props = $props();
+
+  function formatStreak(value: number) {
+    return value > 0 ? `🔥 ${formatNumber(value)}` : formatNumber(value);
+  }
 
   function formatPercentage(value: number) {
     return `${Math.round(value * 100)}%`;
@@ -43,6 +55,8 @@
     <ProfileStatKpi kpi="Quizzes Completed" value={formatNumber(completedQuizzes)} />
     <ProfileStatKpi kpi="Accuracy" value={formatPercentage(accuracy)} />
     <ProfileStatKpi kpi="Rank" value={formatRating(rank)} />
+    <ProfileStatKpi kpi="Current Streak" value={formatStreak(currentStreak)} />
+    <ProfileStatKpi kpi="Longest Streak" value={formatStreak(longestStreak)} />
   </div>
 </section>
 
@@ -57,6 +71,7 @@
 
   .kpis {
     display: flex;
+    flex-wrap: wrap;
     gap: 20px;
   }
 </style>


### PR DESCRIPTION
## What & why

Adds a **day-streak** metric for each user — the number of consecutive days on which they've completed at least one quiz — and surfaces it on the profile page. Fills in the existing `<!--TODO Day streak -->` placeholders.

A streak is the count of consecutive active days, where the allowed gap between active days is governed by a configurable `STREAK_WINDOW_DAYS` constant (default `1` = strict day-over-day). The **current** streak only counts if the most recent active day is within the window of today (otherwise it has lapsed → 0). A **longest** streak is also tracked.

## Changes

- **`prisma/schema.prisma`** — `currentStreak` / `longestStreak` (`Int @default(0)`) on `UserStats`, with an additive migration (`20260615025159_user_stats_streak`).
- **`src/lib/streak.ts`** — pure `computeStreaks(activeDates, windowDays, today)` helper.
- **`src/lib/streak.test.ts`** — 9 unit tests (single day, consecutive runs, lapsed streak, gaps, dedupe, custom windows, past-vs-current longest).
- **`src/lib/constants.ts`** — `STREAK_WINDOW_DAYS`.
- **`src/routes/api/quiz/questions/+server.ts`** — after a quiz completes, recomputes streaks from the existing per-day `UserStatsTrends` rows and persists them. Deriving from the source of truth keeps the values self-healing rather than relying on increment/reset bookkeeping.
- **`ProfileStats.svelte`** / **`profile/+page.svelte`** — Current/Longest Streak KPIs (🔥 when active), wrapping enabled on the KPI row, removed satisfied TODOs.

## Verification

- Drove the real flow against the local DB: completing one quiz → streak `1`; backdating 3 consecutive trend days + another completion → recomputed to `4` for both current and longest, rendered as 🔥 4 on the profile.
- `prettier` clean, `svelte-check` 0 errors/warnings, **41/41** unit tests pass.

## Reviewer notes

- Migration is additive; existing users show `0` until their next quiz completion triggers a recompute. Happy to add a one-time backfill script if immediate accuracy for existing data is desired.
- `STREAK_WINDOW_DAYS` is the knob for the "past n days" definition — currently `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)