### PR TITLE
Fix quiz answer grading, name validation, and quiz access control

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import prisma from '../src/lib/prisma.ts';
+import { QuestionType } from '../src/lib/types.ts';
 
 // Define the interface for each question
 interface RawQuestion {
@@ -13,7 +14,7 @@ interface RawQuestion {
 interface GeneratedQuestion {
   title: string;
   prompt: string;
-  type: string;
+  type: QuestionType;
   multiple_choice: string[];
   answers: string[];
   tags: string[];
@@ -43,7 +44,7 @@ const generate_question_permutations = (question: RawQuestion) => {
     permutations.push({
       title: question.title,
       prompt: question.prompt,
-      type: 'multiple_choice',
+      type: QuestionType.MultipleChoice,
       multiple_choice: question.answers.concat(shuffled_false_answers.slice(0, 3)),
       answers: question.answers,
       tags: question.tags
@@ -54,7 +55,7 @@ const generate_question_permutations = (question: RawQuestion) => {
     permutations.push({
       title: question.title,
       prompt: question.prompt,
-      type: 'multiple_choice',
+      type: QuestionType.MultipleChoice,
       multiple_choice: shuffled_false_answers.slice(0, 4),
       answers: [],
       tags: question.tags
@@ -65,7 +66,7 @@ const generate_question_permutations = (question: RawQuestion) => {
   permutations.push({
     title: question.title,
     prompt: question.prompt,
-    type: 'blind_answer',
+    type: QuestionType.BlindAnswer,
     multiple_choice: [],
     answers: question.answers,
     tags: question.tags

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import Button from './Button.svelte';
   import RadioGroup from './RadioGroup.svelte';
-  import type { ParsedMultipleChoiceOptions, Question } from '$lib/types';
+  import { QuestionType, type ParsedMultipleChoiceOptions, type Question } from '$lib/types';
 
   let answer = $state('');
   let questionPromise: Promise<Question> | undefined = $state();
@@ -75,9 +75,9 @@
             <p id="question-title">{question.title}</p>
           {/if}
           <h2>{question.prompt}</h2>
-          {#if question.type === 'blind_answer'}
+          {#if question.type === QuestionType.BlindAnswer}
             <input type="text" placeholder="Enter your answer" onchange={handleAnswerChange} />
-          {:else if question.type === 'multiple_choice'}
+          {:else if question.type === QuestionType.MultipleChoice}
             <RadioGroup
               label="label"
               options={parseMultipleChoiceOptions(question.multipleChoiceOptions)}
@@ -90,7 +90,8 @@
             <Button
               onclick={() => submitHandler(answer)}
               kind="secondary"
-              disabled={question.type !== 'multiple_choice' && !haveAnswer(answer)}>Submit</Button
+              disabled={question.type !== QuestionType.MultipleChoice && !haveAnswer(answer)}
+              >Submit</Button
             >
           </div>
         </form>

--- a/src/lib/server/validation/validateName.ts
+++ b/src/lib/server/validation/validateName.ts
@@ -24,7 +24,7 @@ export const validateName = (name: string) => {
     return { isValid: false, invalidReason: 'Names cannot be more than 50 characters long' };
   }
 
-  if (name.length <= 1) {
+  if (name.length < 1) {
     return { isValid: false, invalidReason: 'Names must be at least 1 character long' };
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,14 @@
+enum QuestionType {
+  MultipleChoice = 'multiple_choice',
+  BlindAnswer = 'blind_answer'
+}
+
 interface Question {
   id: string;
   family: string;
   title: string;
   prompt: string;
-  type: string;
+  type: QuestionType;
   multipleChoiceOptions: string;
   answers: string;
   tags: string;
@@ -43,6 +48,8 @@ interface ParsedMultipleChoiceOptions {
   label: string;
   value: string;
 }
+
+export { QuestionType };
 
 export type {
   Question,

--- a/src/routes/api/quiz/questions/+server.ts
+++ b/src/routes/api/quiz/questions/+server.ts
@@ -1,14 +1,35 @@
 import prisma from '$lib/prisma';
 import { json } from '@sveltejs/kit';
 import { updateEloRankings } from '$lib/eloRating';
-import type { QuizDataWithoutQuestions } from '$lib/types';
+import { QuestionType, type QuizDataWithoutQuestions } from '$lib/types';
 import { getUTCDate } from '$lib/datetime/date';
 
-export const POST = async ({ request }) => {
+export const POST = async ({ request, locals }) => {
+  // The caller must be signed in (guests included) to submit answers.
+  const userId = locals.user?.id;
+  if (!userId) {
+    return json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { quizId, questionId, userAnswer } = await request.json();
 
   if (!quizId || !questionId) {
     return json({ error: 'Missing quizId or questionId' }, { status: 400 });
+  }
+
+  // Ensure the quiz exists and belongs to the requesting user before mutating it.
+  const quiz = await prisma.quiz.findUnique({
+    select: { userId: true, isCompleted: true },
+    where: { id: quizId }
+  });
+  if (!quiz) {
+    return json({ error: 'Quiz not found' }, { status: 404 });
+  }
+  if (quiz.userId !== userId) {
+    return json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (quiz.isCompleted) {
+    return json({ error: 'Quiz already completed' }, { status: 400 });
   }
 
   // Get the question to validate the user's answer
@@ -20,19 +41,26 @@ export const POST = async ({ request }) => {
     return json({ error: 'Question not found' }, { status: 404 });
   }
 
-  // Check if the question is already answered
+  // Check that the question is part of this quiz and isn't already answered.
   const existingAnswer = await prisma.quizQuestion.findUnique({
     select: { isAnswered: true },
     where: { quizId_questionId: { quizId, questionId } }
   });
-  if (existingAnswer && existingAnswer.isAnswered) {
+  if (!existingAnswer) {
+    return json({ error: 'Question is not part of this quiz' }, { status: 404 });
+  }
+  if (existingAnswer.isAnswered) {
     return json({ error: 'Question already answered' }, { status: 400 });
   }
 
   // Validate the user's answer
   const correctAnswers = JSON.parse(question.answers);
   let isCorrect = false;
-  if (question.type === 'multiple-choice' && correctAnswers.length === 0 && userAnswer === '') {
+  if (
+    question.type === QuestionType.MultipleChoice &&
+    correctAnswers.length === 0 &&
+    userAnswer === ''
+  ) {
     isCorrect = true;
   } else {
     isCorrect = correctAnswers.includes(userAnswer);


### PR DESCRIPTION
## What changed

Three bug fixes surfaced while auditing the quiz flow:

### 1. `QuestionType` enum — fixes ungradeable trick questions
The grading endpoint compared `question.type === 'multiple-choice'` (hyphen), but the seeded data stores `'multiple_choice'` (underscore). That branch was dead code, so the "all options wrong, answer nothing" trick questions (`answers: []`) could **never** be marked correct — silently skewing scores, accuracy, and Elo ratings.

Fixed by introducing a `QuestionType` string enum (`MultipleChoice = 'multiple_choice'`, `BlindAnswer = 'blind_answer'`) in `src/lib/types.ts` and using it everywhere the literals previously appeared: `prisma/seed.ts`, `Question.svelte`, and the grading endpoint. The enum makes the canonical values single-source and prevents the typo from recurring.

### 2. `validateName` minimum length
Changed `name.length <= 1` to `name.length < 1`, so single-character names are accepted and the "Names must be at least 1 character long" message actually matches the rule. Existing tests still pass.

### 3. Server-side quiz authorization (IDOR fix)
`POST /api/quiz/questions` previously accepted any `quizId`/`questionId` with no ownership check, letting anyone answer another user's quiz. It now:
- rejects unauthenticated callers (`401`) — guests included, since they carry a session;
- verifies `quiz.userId === locals.user.id`, returning `403` otherwise;
- rejects submissions to an already-completed quiz (`400`);
- returns `404` when the question isn't part of the quiz (previously fell through to a throwing Prisma update).

## Testing
- `npx vitest run` — all 32 unit tests pass.
- `npm run check` — no new type errors (2 pre-existing `PUBLIC_SENTRY_DSN` env errors are unrelated to this change).

## Notes for reviewers
- The sibling route `quiz/results/[quizId]/+page.server.ts` still lets anyone *view* a completed quiz's results by ID. This PR only locks down *answering*; read-side access control can be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)