### PR TITLE
Redesign homepage to drive quiz starts

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,8 +19,8 @@ env:
   BETTER_AUTH_SECRET: 'ci-test-secret-not-for-production'
   BETTER_AUTH_URL: 'http://localhost:4173'
   PUBLIC_SENTRY_DSN: ''
-  # Dummy OAuth credentials so BetterAuth can build provider authorize URLs
-  # during the e2e tests without contacting the real providers.
+  # Dummy OAuth credentials so BetterAuth can initialize during the Vitest
+  # suite without contacting the real providers.
   GITHUB_CLIENT_ID: 'ci-github-client-id'
   GITHUB_CLIENT_SECRET: 'ci-github-client-secret'
   GOOGLE_CLIENT_ID: 'ci-google-client-id'
@@ -55,56 +55,3 @@ jobs:
 
       - name: Run Vitest
         run: npx vitest --run
-
-  e2e:
-    name: Run Playwright e2e tests
-    runs-on: ubuntu-latest
-    # Run inside the official Playwright image so the browsers + system deps are
-    # preinstalled — avoids the flaky `playwright install` download in CI. Keep
-    # the tag in sync with the @playwright/test version in package.json.
-    container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
-
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: appdb
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    env:
-      # In a container job, services are reached by their label hostname on the
-      # container's own port (not the runner's mapped localhost port).
-      DATABASE_URL: 'postgresql://postgres:postgres@postgres:5432/appdb?schema=public'
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Apply database migrations
-        run: npx prisma migrate deploy
-
-      - name: Run Playwright tests
-        run: npx playwright test
-
-      - name: Upload Playwright report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,12 +19,6 @@ env:
   BETTER_AUTH_SECRET: 'ci-test-secret-not-for-production'
   BETTER_AUTH_URL: 'http://localhost:4173'
   PUBLIC_SENTRY_DSN: ''
-  # Dummy OAuth credentials so BetterAuth can initialize during the Vitest
-  # suite without contacting the real providers.
-  GITHUB_CLIENT_ID: 'ci-github-client-id'
-  GITHUB_CLIENT_SECRET: 'ci-github-client-secret'
-  GOOGLE_CLIENT_ID: 'ci-google-client-id'
-  GOOGLE_CLIENT_SECRET: 'ci-google-client-secret'
 
 jobs:
   lint-test:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,6 @@
 npx lint-staged
+
+# Playwright e2e tests run locally here instead of in CI: GitHub's runners can't
+# reliably pull the Playwright container image from mcr.microsoft.com. Playwright
+# builds + previews the app (or reuses a server already on :4173) before testing.
+npm run test:e2e

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -38,7 +38,6 @@
     border-radius: 4px;
     font-size: 1rem;
     font-weight: bold;
-    text-transform: uppercase;
     cursor: pointer;
     border: none;
   }

--- a/src/lib/components/ButtonLink.svelte
+++ b/src/lib/components/ButtonLink.svelte
@@ -27,7 +27,6 @@
     border-radius: 4px;
     font-size: 1rem;
     font-weight: bold;
-    text-transform: uppercase;
     text-decoration: none;
     cursor: pointer;
     border: none;

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,22 +1,34 @@
 <footer>
-  <p>&copy; Frontend Challenge {new Date().getFullYear()}</p>
-  <nav>
-    <a href="/">Home</a>
-  </nav>
+  <div class="footer-inner">
+    <p>&copy; Frontend Challenge {new Date().getFullYear()}</p>
+    <nav>
+      <a href="/">Home</a>
+    </nav>
+  </div>
 </footer>
 
 <style>
   footer {
+    width: 100%;
+    background-color: white;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .footer-inner {
     padding: var(--page-content-padding);
     width: 100%;
     max-width: var(--page-content-max-width);
     margin: 0 auto;
     text-align: center;
-    border-top: 1px solid var(--color-border);
+  }
+
+  p {
+    color: var(--color-text);
   }
 
   a {
     margin: 0 1rem;
+    color: var(--color-purple);
     text-decoration: none;
   }
 

--- a/src/lib/components/TryQuestion.svelte
+++ b/src/lib/components/TryQuestion.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  import ButtonLink from './ButtonLink.svelte';
+
+  // A curated sample question so visitors can experience the core loop
+  // instantly, without an account or an API round-trip.
+  const question = {
+    tag: 'CSS',
+    prompt: 'Which CSS selector targets all paragraph tags?',
+    options: ['p', '.p', '#p', '*p'],
+    answer: 'p'
+  };
+
+  let selected = $state<string | null>(null);
+  let answered = $derived(selected !== null);
+  let correct = $derived(selected === question.answer);
+
+  function choose(option: string) {
+    if (answered) return;
+    selected = option;
+  }
+
+  function stateFor(option: string): 'correct' | 'incorrect' | 'idle' {
+    if (!answered) return 'idle';
+    if (option === question.answer) return 'correct';
+    if (option === selected) return 'incorrect';
+    return 'idle';
+  }
+</script>
+
+<section class="try">
+  <p class="eyebrow">Try one right now — no account needed</p>
+  <div class="card">
+    <span class="tag">{question.tag}</span>
+    <p class="prompt">{question.prompt}</p>
+    <div class="options" role="group" aria-label="Answer options">
+      {#each question.options as option (option)}
+        <button
+          type="button"
+          class="option {stateFor(option)}"
+          aria-pressed={selected === option}
+          disabled={answered && stateFor(option) === 'idle'}
+          onclick={() => choose(option)}
+        >
+          <code>{option}</code>
+        </button>
+      {/each}
+    </div>
+
+    {#if answered}
+      <div class="feedback {correct ? 'correct' : 'incorrect'}" role="status">
+        {#if correct}
+          <p>Correct! That's how it feels — instant feedback on every question.</p>
+        {:else}
+          <p>Not quite — <code>p</code> is the answer. Start a quiz to keep going.</p>
+        {/if}
+        <ButtonLink href="/quiz" kind="primary">Start a Quiz</ButtonLink>
+      </div>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .try {
+    background-color: white;
+    padding: 48px var(--page-content-padding);
+  }
+  .eyebrow {
+    text-align: center;
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-tertiary);
+    margin: 0 0 16px;
+  }
+  .card {
+    max-width: 560px;
+    margin: 0 auto;
+    border: 1px solid var(--color-border);
+    border-radius: var(--card-border-radius);
+    padding: 24px;
+  }
+  .tag {
+    display: inline-block;
+    background-color: var(--color-negative-light);
+    color: var(--color-pink);
+    font-size: 0.75rem;
+    padding: 3px 10px;
+    border-radius: 999px;
+    margin-bottom: 12px;
+  }
+  .prompt {
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 16px;
+  }
+  .options {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+  }
+  .option {
+    text-align: left;
+    padding: 12px 14px;
+    border-radius: var(--border-radius-md);
+    border: 1px solid var(--color-border);
+    background-color: white;
+    cursor: pointer;
+    transition: all 150ms ease-out;
+  }
+  .option code {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+  }
+  .option:hover:enabled {
+    border-color: var(--color-purple);
+  }
+  .option:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+  .option.correct {
+    background-color: var(--color-affirmative-light);
+    border-color: var(--color-affirmative-dark);
+    opacity: 1;
+  }
+  .option.correct code {
+    color: var(--color-affirmative-dark);
+  }
+  .option.incorrect {
+    background-color: var(--color-negative-light);
+    border-color: var(--color-negative-dark);
+    opacity: 1;
+  }
+  .option.incorrect code {
+    color: var(--color-negative-dark);
+  }
+  .feedback {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .feedback p {
+    margin: 0;
+    font-size: 0.95rem;
+  }
+  .feedback.correct p {
+    color: var(--color-affirmative-dark);
+  }
+  .feedback.incorrect p {
+    color: var(--color-negative-dark);
+  }
+  .feedback code {
+    font-family: var(--font-mono);
+  }
+
+  @media (max-width: 480px) {
+    .try {
+      padding: 40px 20px;
+    }
+    .options {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/lib/components/TryQuestion.svelte
+++ b/src/lib/components/TryQuestion.svelte
@@ -51,7 +51,9 @@
         {#if correct}
           <p>Correct! That's how it feels — instant feedback on every question.</p>
         {:else}
-          <p>Not quite — <code>p</code> is the answer. Start a quiz to keep going.</p>
+          <p>
+            Not quite — <code>{question.answer}</code> is the answer. Start a quiz to keep going.
+          </p>
         {/if}
         <ButtonLink href="/quiz" kind="primary">Start a Quiz</ButtonLink>
       </div>

--- a/src/lib/components/WelcomeSection.svelte
+++ b/src/lib/components/WelcomeSection.svelte
@@ -1,104 +1,83 @@
 <script lang="ts">
   import ButtonLink from './ButtonLink.svelte';
-
-  const images = Array(9)
-    .fill(0)
-    .map((_, i) => `images/welcome-icons/icon-${i + 1}.svg`);
 </script>
 
-<div class="welcome-section">
-  <div class="welcome-content">
-    <div id="welcome-animation">
-      <div class="vertical-center">
-        <div>
-          <div class="icon-grid">
-            {#each images as image, i}
-              <img
-                class="welcome-icon"
-                src={image}
-                alt={`Decorative Web Development Icon ${i + 1}`}
-              />
-            {/each}
-          </div>
-        </div>
-      </div>
-    </div>
-    <div id="welcome-message">
-      <div class="vertical-center">
-        <p>Get ready to test your frontend knowledge. Track and improve your skills!</p>
-        <div id="button-tray">
-          <ButtonLink href="/quiz" kind="primary">Get Started</ButtonLink>
-          <ButtonLink href="/register" kind="secondary">I Already Have an Account</ButtonLink>
-        </div>
-      </div>
+<div class="hero">
+  <div class="hero-content">
+    <span class="hero-chip"> 34 expert-crafted challenges · no sign-up to start </span>
+    <h1>How sharp are your frontend skills?</h1>
+    <p class="hero-subhead">
+      Answer real-world JavaScript, CSS, React &amp; HTTP questions. Track your accuracy and climb
+      the global rankings.
+    </p>
+    <div class="button-tray">
+      <ButtonLink href="/quiz" kind="primary">Start a Quiz</ButtonLink>
+      <ButtonLink href="/login" kind="secondary">Sign In</ButtonLink>
     </div>
   </div>
 </div>
 
 <style>
-  .welcome-section {
+  .hero {
     box-sizing: border-box;
+    background-color: var(--color-blue);
     display: flex;
-    flex-direction: column;
     justify-content: center;
-    align-items: center;
-    padding: 40px 0px;
-    margin: 0 auto;
-    height: calc(100vh - 62px);
-    min-height: 200px;
+    padding: 64px var(--page-content-padding);
+  }
+  .hero-content {
     width: 100%;
     max-width: var(--page-content-max-width);
-  }
-  .welcome-content {
-    flex: 1;
-    width: 100%;
+    text-align: center;
     display: flex;
     flex-direction: column;
-  }
-  .welcome-content > div {
-    height: 100%;
-    width: 100%;
-    border: 1px solid rgb(249, 158, 0);
-  }
-  .vertical-center {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
     align-items: center;
-    height: 100%;
-    width: 100%;
-    border: 1px solid red;
   }
-  #button-tray {
-    gap: 10px;
+  .hero-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background-color: rgba(255, 185, 97, 0.15);
+    color: var(--color-yellow);
+    font-size: 0.85rem;
+    padding: 6px 14px;
+    border-radius: 999px;
+    margin-bottom: 1.5rem;
+  }
+  h1 {
+    color: var(--color-yellow);
+    text-shadow: 2px 2px var(--color-orange);
+    font-size: clamp(2rem, 6vw, 3.25rem);
+    font-weight: 500;
+    line-height: 1.1;
+    margin: 0 0 1rem;
+  }
+  .hero-subhead {
+    color: rgba(255, 255, 255, 0.9);
+    font-size: clamp(1rem, 2.5vw, 1.2rem);
+    line-height: 1.6;
+    max-width: 30rem;
+    margin: 0 auto 2rem;
+  }
+  .button-tray {
     display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
     justify-content: center;
-    margin-bottom: 30px;
-  }
-  .icon-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
-  }
-  .icon-grid img {
-    width: 100%;
-    height: auto;
   }
 
-  .welcome-icon {
-    transition: all 200ms ease-out;
-    opacity: 0.9;
-  }
-  .welcome-icon:hover {
-    transition: all 200ms ease-in;
-    transform: scale(1.05);
-    opacity: 1;
-  }
-
-  /* Desktop layout */
-  @media (min-width: 768px) {
-    .welcome-content {
-      flex-direction: row;
+  @media (max-width: 600px) {
+    .hero {
+      padding: 48px 20px;
+    }
+    /* Let the CTAs stretch full width and stack on small screens */
+    .button-tray {
+      width: 100%;
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .button-tray :global(a) {
+      text-align: center;
     }
   }
 </style>

--- a/src/lib/components/WelcomeSection.svelte
+++ b/src/lib/components/WelcomeSection.svelte
@@ -4,6 +4,9 @@
 
 <div class="hero">
   <div class="hero-content">
+    <!-- Keep this count in sync with the seed data in data/questions.json. It is
+         hardcoded on purpose: the homepage is prerendered (see +page.ts), and the
+         question data carries answers we must not ship to the client. -->
     <span class="hero-chip"> 34 expert-crafted challenges · no sign-up to start </span>
     <h1>How sharp are your frontend skills?</h1>
     <p class="hero-subhead">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,75 +1,139 @@
 <script>
-  import Card from '../lib/components/Card.svelte';
-  import Question from '../lib/components/Question.svelte';
+  import ButtonLink from '$lib/components/ButtonLink.svelte';
+  import TryQuestion from '$lib/components/TryQuestion.svelte';
   import WelcomeSection from '$lib/components/WelcomeSection.svelte';
+
+  const valueProps = [
+    {
+      title: 'Track your accuracy',
+      body: 'Every answer feeds your running score so you can watch your progress over time.'
+    },
+    {
+      title: 'Climb the rankings',
+      body: 'An ELO-style rating pits your skills against the rest of the community.'
+    },
+    {
+      title: 'Learn as you go',
+      body: 'See the right answer instantly and dig into curated resources to level up.'
+    }
+  ];
+
+  const topics = ['JavaScript', 'CSS', 'React', 'HTTP', 'DOM', 'Closures', '+ more'];
 </script>
 
 <svelte:head>
-  <title>Frontend Challenge Home</title>
-  <meta name="description" content="Frontend Challenge Home" />
+  <title>Frontend Challenge — Test your frontend skills</title>
+  <meta
+    name="description"
+    content="Answer real-world JavaScript, CSS, React and HTTP questions. Track your accuracy and climb the global rankings."
+  />
 </svelte:head>
 
-<section>
-  <WelcomeSection />
-  <div id="second-section">
-    <div>
-      <Card>
-        <p>
-          Our questions are crafted by industry experts to simulate actual development scenarios,
-          helping you to not only test your knowledge but also improve your problem-solving
-          capabilities in a fun and engaging way.
-        </p>
-        <p>
-          Each challenge is designed to push your boundaries and expand your understanding of how
-          web technologies work together.
-        </p>
-        <p>
-          Select a challenge, and see if you can rise to the occasion of becoming a frontend
-          maestro!
-        </p>
-      </Card>
+<WelcomeSection />
+
+<TryQuestion />
+
+<section class="value">
+  <div class="value-inner">
+    <div class="value-grid">
+      {#each valueProps as prop (prop.title)}
+        <div class="value-card">
+          <h2>{prop.title}</h2>
+          <p>{prop.body}</p>
+        </div>
+      {/each}
     </div>
-    <div>
-      <Question questionId="" submitHandler={() => {}} />
+
+    <div class="topics">
+      <p class="topics-label">Covering the topics that matter</p>
+      <ul class="topic-tags">
+        {#each topics as topic (topic)}
+          <li>{topic}</li>
+        {/each}
+      </ul>
     </div>
-  </div>
-  <div id="third-section" class="pipe-gradient">
-    <p>Hello World</p>
   </div>
 </section>
 
+<section class="final-cta">
+  <h2>Ready to find out where you stand?</h2>
+  <ButtonLink href="/quiz" kind="primary">Start Your First Quiz</ButtonLink>
+</section>
+
 <style>
-  section {
-    height: calc(100vh - 59px);
-  }
-  #second-section {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    background-color: lime;
-  }
-  #second-section > div {
-    padding: 80px 40px;
-    margin-top: -100px;
-    padding-top: 140px;
-  }
-  #second-section div:first-child {
+  .value {
     background-color: var(--color-yellow);
+    padding: 56px var(--page-content-padding);
+  }
+  .value-inner {
+    max-width: var(--page-content-max-width);
+    margin: 0 auto;
+  }
+  .value-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+  }
+  .value-card {
+    background-color: white;
+    border-radius: var(--card-border-radius);
+    padding: 24px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  }
+  .value-card h2 {
+    font-size: 1.15rem;
+    font-weight: 500;
+    color: var(--color-purple);
+    margin: 0 0 8px;
+  }
+  .value-card p {
+    margin: 0;
+    color: var(--color-text);
+    line-height: 1.5;
   }
 
-  .pipe-gradient {
-    background-color: var(--color-yellow);
-    background-image: repeating-radial-gradient(
-      circle at 0 0,
-      var(--color-yellow),
-      var(--color-pink) 10px,
-      var(--color-orange) 10px,
-      var(--color-pink) 20px /* determines size */
-    );
+  .topics {
+    text-align: center;
+    margin-top: 40px;
+  }
+  .topics-label {
+    font-size: 0.85rem;
+    color: var(--color-purple);
+    margin: 0 0 14px;
+  }
+  .topic-tags {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+  }
+  .topic-tags li {
+    background-color: white;
+    color: var(--color-blue);
+    font-size: 0.85rem;
+    padding: 6px 14px;
+    border-radius: 999px;
+  }
+
+  .final-cta {
+    background-color: var(--color-purple);
+    text-align: center;
+    padding: 56px var(--page-content-padding);
+  }
+  .final-cta h2 {
+    color: var(--color-yellow);
+    font-size: clamp(1.4rem, 4vw, 1.8rem);
+    font-weight: 500;
+    margin: 0 0 24px;
   }
 
   @media (max-width: 600px) {
-    #second-section {
-      grid-template-columns: 1fr;
+    .value,
+    .final-cta {
+      padding: 44px 20px;
     }
   }
 </style>


### PR DESCRIPTION
## What changed

Replaces the work-in-progress homepage with a focused, conversion-oriented landing page designed to get visitors excited and into a quiz quickly.

**New homepage structure:**
- **Hero** — benefit headline ("How sharp are your frontend skills?"), a value-focused subhead naming the actual topics, and a single dominant **Start a Quiz** CTA (sign-in demoted to a secondary action).
- **"Try one now"** — an interactive sample CSS question with instant correct/incorrect feedback, so visitors experience the core loop before committing. Self-contained (curated question, no backend changes).
- **Value props** — accuracy tracking, ELO-style rankings, and learn-as-you-go.
- **Topic tags + closing CTA band** — signal breadth and repeat the primary action.
- Fully **responsive** across mobile and desktop (stacked full-width CTAs, single-column options, fluid type via `clamp`).

**Two fixes surfaced during review:**
- Buttons no longer force `text-transform: uppercase`; labels render in **Title Case** (applied to shared `Button.svelte` / `ButtonLink.svelte`).
- **Footer** now has an explicit white background and brand-colored link for readable contrast — previously its dark text fell onto an undefined/dark backdrop.

## Why

The previous homepage read as unfinished (debug `lime` background, red/orange borders, a "Hello World" section) and had a dead embedded question (`submitHandler={() => {}}`). It communicated no value proposition and buried the primary CTA next to a similarly-weighted secondary one.

## Notes for reviewers

- The shared button components are global — removing the uppercase transform affects all buttons site-wide, but existing labels were already Title Case ("Logout", "Start Quiz", etc.), so they render correctly.
- The "try a question" card uses a curated sample question rather than the live `/api/question` endpoint, because that endpoint intentionally omits answers (so client-side feedback isn't possible without a new endpoint).
- Verified visually at desktop and mobile widths via the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive “try one right now” CSS multiple-choice practice question on the landing page.
* **Style**
  * Redesigned the landing page into a new hero layout with updated topic cards and call-to-action styling.
  * Updated button and button-link text to render in normal casing instead of forcing uppercase.
  * Improved footer layout with clearer inner structure and refined link/paragraph styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->