### PR TITLE
Add Support page and apply ocean color palette

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ test-results/**/error-context.md
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Claude Code agent worktrees
+.claude/worktrees/

--- a/src/lib/components/ButtonLink.svelte
+++ b/src/lib/components/ButtonLink.svelte
@@ -50,6 +50,7 @@
     /* Secondary button styles */
     background-color: white;
     color: var(--color-blue);
+    outline: 1px solid var(--color-text-secondary);
   }
 
   .c-button-warning {

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -15,6 +15,6 @@
     background-color: white;
     border-radius: var(--card-border-radius);
     padding: 16px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 </style>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -3,6 +3,7 @@
     <p>&copy; Frontend Challenge {new Date().getFullYear()}</p>
     <nav>
       <a href="/">Home</a>
+      <a href="/support">Support</a>
     </nav>
   </div>
 </footer>

--- a/src/lib/components/QuestionTag.svelte
+++ b/src/lib/components/QuestionTag.svelte
@@ -14,7 +14,7 @@
     '#de4d1c', // tomato
     '#c4393e', // red-sun
     '#5f7081', // mist
-    '#3a3a3a'  // charcoal
+    '#3a3a3a' // charcoal
   ];
 
   function getColor(tag: string) {

--- a/src/lib/components/QuestionTag.svelte
+++ b/src/lib/components/QuestionTag.svelte
@@ -5,16 +5,16 @@
 
   let { tag }: Props = $props();
   const colors = [
-    '#636EFA',
-    '#EF553B',
-    '#00CC96',
-    '#AB63FA',
-    '#FFA15A',
-    '#19D3F3',
-    '#FF6692',
-    '#B6E880',
-    '#FF97FF',
-    '#FECB52'
+    '#008f98', // teal
+    '#1c4067', // navy
+    '#5e8fbe', // sky-blue
+    '#495363', // slate
+    '#e78571', // salmon
+    '#f2973d', // tangerine
+    '#de4d1c', // tomato
+    '#c4393e', // red-sun
+    '#5f7081', // mist
+    '#3a3a3a'  // charcoal
   ];
 
   function getColor(tag: string) {

--- a/src/lib/components/WelcomeSection.svelte
+++ b/src/lib/components/WelcomeSection.svelte
@@ -40,7 +40,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    background-color: rgba(255, 185, 97, 0.15);
+    background-color: rgba(255, 237, 79, 0.15);
     color: var(--color-yellow);
     font-size: 0.85rem;
     padding: 6px 14px;

--- a/src/lib/components/auth/AuthTextInput.svelte
+++ b/src/lib/components/auth/AuthTextInput.svelte
@@ -38,7 +38,7 @@
 
   input {
     padding: 0.5rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--ocean-color-mist-light);
     border-radius: 4px;
     display: block;
     width: 100%;
@@ -46,12 +46,12 @@
   }
 
   .error-input {
-    border-color: red;
-    background-color: rgba(255, 0, 0, 0.05);
+    border-color: var(--ocean-color-red-sun);
+    background-color: var(--ocean-color-pale-pink);
   }
 
   .error-message {
     margin-top: 2px;
-    color: red;
+    color: var(--ocean-color-red-sun);
   }
 </style>

--- a/src/lib/components/form/ErrorMessage.svelte
+++ b/src/lib/components/form/ErrorMessage.svelte
@@ -12,6 +12,6 @@
 
 <style>
   .error {
-    color: red;
+    color: var(--ocean-color-red-sun);
   }
 </style>

--- a/src/lib/ocean-palette.css
+++ b/src/lib/ocean-palette.css
@@ -1,0 +1,76 @@
+/* Ocean color palette */
+
+:root {
+  /* ─── Neutrals ─── */
+  --ocean-color-white: #ffffff;
+  --ocean-color-cream: #f6f2e8;
+  --ocean-color-lightest-gray: #f8f8f8;
+  --ocean-color-cloud: #f0f1f3;
+  --ocean-color-ice: #edf1fa;
+  --ocean-color-mist-light: #d1d6dc;
+  --ocean-color-mist: #5f7081;
+  --ocean-color-slate: #495363;
+  --ocean-color-charcoal: #3a3a3a;
+
+  /* Neutrals with opacity baked in */
+  --ocean-color-slate-22: #49536338; /* slate @ ~22% */
+  --ocean-color-mist-30: #66788b4d;  /* mist @ ~30% */
+
+  /* ─── Accent ─── */
+  --ocean-color-teal: #008f98;
+  --ocean-color-navy: #1c4067;
+  --ocean-color-sky-blue: #5e8fbe;
+  --ocean-color-pale-blue: #d8e9ff;
+
+  --ocean-color-pale-yellow: #fdf5d2;
+  --ocean-color-fe-yellow: #ffed4f;
+  --ocean-color-cheese-yellow: #fec022;
+  --ocean-color-sun-yellow: #feda59;
+
+  --ocean-color-pale-pink: #fde9ff;
+  --ocean-color-salmon: #e78571;
+  --ocean-color-tangerine: #f2973d;
+  --ocean-color-tomato: #de4d1c;
+  --ocean-color-red-sun: #c4393e;
+
+  /* ─── Gradients ─── */
+
+  /* Named gradient tokens (use var() references so they update if colors change) */
+  --ocean-gradient-teal-to-tomato: linear-gradient(
+    90deg,
+    var(--ocean-color-teal) 0%,
+    var(--ocean-color-tomato) 100%
+  );
+  --ocean-gradient-cream-to-pale-yellow: linear-gradient(
+    180deg,
+    var(--ocean-color-cream) 0%,
+    var(--ocean-color-pale-yellow) 100%
+  );
+
+  /* Directional / background-image gradients */
+  --ocean-gradient-teal-to-sky-blue: linear-gradient(
+    274deg,
+    #008f98 -2.66%,
+    #5e8fbe 55.61%
+  );
+  --ocean-gradient-teal-to-tomato-bg: linear-gradient(
+    248deg,
+    #de4d1c 14.33%,
+    #008f98 78.73%
+  );
+  --ocean-gradient-cheese-to-sun: linear-gradient(
+    0deg,
+    #fec022 -14.81%,
+    #feeb7b 164.44%
+  );
+  --ocean-gradient-cream-to-pale-yellow-bg: linear-gradient(
+    180deg,
+    #f6f2e8 0%,
+    #fff5d0 100%
+  );
+  --ocean-gradient-fit-box: linear-gradient(
+    268deg,
+    #39abb233 2.05%,
+    #8fb8d633 54.62%
+  );
+}

--- a/src/lib/ocean-palette.css
+++ b/src/lib/ocean-palette.css
@@ -14,7 +14,7 @@
 
   /* Neutrals with opacity baked in */
   --ocean-color-slate-22: #49536338; /* slate @ ~22% */
-  --ocean-color-mist-30: #66788b4d;  /* mist @ ~30% */
+  --ocean-color-mist-30: #66788b4d; /* mist @ ~30% */
 
   /* ─── Accent ─── */
   --ocean-color-teal: #008f98;
@@ -48,29 +48,9 @@
   );
 
   /* Directional / background-image gradients */
-  --ocean-gradient-teal-to-sky-blue: linear-gradient(
-    274deg,
-    #008f98 -2.66%,
-    #5e8fbe 55.61%
-  );
-  --ocean-gradient-teal-to-tomato-bg: linear-gradient(
-    248deg,
-    #de4d1c 14.33%,
-    #008f98 78.73%
-  );
-  --ocean-gradient-cheese-to-sun: linear-gradient(
-    0deg,
-    #fec022 -14.81%,
-    #feeb7b 164.44%
-  );
-  --ocean-gradient-cream-to-pale-yellow-bg: linear-gradient(
-    180deg,
-    #f6f2e8 0%,
-    #fff5d0 100%
-  );
-  --ocean-gradient-fit-box: linear-gradient(
-    268deg,
-    #39abb233 2.05%,
-    #8fb8d633 54.62%
-  );
+  --ocean-gradient-teal-to-sky-blue: linear-gradient(274deg, #008f98 -2.66%, #5e8fbe 55.61%);
+  --ocean-gradient-teal-to-tomato-bg: linear-gradient(248deg, #de4d1c 14.33%, #008f98 78.73%);
+  --ocean-gradient-cheese-to-sun: linear-gradient(0deg, #fec022 -14.81%, #feeb7b 164.44%);
+  --ocean-gradient-cream-to-pale-yellow-bg: linear-gradient(180deg, #f6f2e8 0%, #fff5d0 100%);
+  --ocean-gradient-fit-box: linear-gradient(268deg, #39abb233 2.05%, #8fb8d633 54.62%);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,7 +62,7 @@
 
 <style>
   .value {
-    background-color: var(--color-yellow);
+    background: var(--ocean-gradient-cream-to-pale-yellow);
     padding: 56px var(--page-content-padding);
   }
   .value-inner {

--- a/src/routes/learn/components/ResourceListing.svelte
+++ b/src/routes/learn/components/ResourceListing.svelte
@@ -35,7 +35,7 @@
 <style>
   a {
     text-decoration: none;
-    color: #333;
+    color: var(--ocean-color-charcoal);
   }
 
   p.link-text:hover {
@@ -49,8 +49,8 @@
     box-shadow:
       0px 1px 2px -1px rgba(0, 0, 0, 0.1),
       0px 1px 3px 0px rgba(0, 0, 0, 0.1);
-    color: #333;
-    background-color: #fff;
+    color: var(--ocean-color-charcoal);
+    background-color: var(--ocean-color-white);
     overflow: hidden;
     display: flex;
     align-items: stretch;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -76,7 +76,7 @@
   div {
     max-width: 400px;
     margin: 100px auto;
-    border: 1px solid #ccc;
+    border: 1px solid var(--ocean-color-mist-light);
     border-radius: var(--card-border-radius);
     padding: 2rem;
   }

--- a/src/routes/profile/components/ProfileHeader.svelte
+++ b/src/routes/profile/components/ProfileHeader.svelte
@@ -34,7 +34,7 @@
     height: 160px;
     border-radius: 50%;
     object-fit: cover;
-    background-color: azure;
+    background-color: var(--ocean-color-ice);
   }
   .username {
     font-size: 24px;

--- a/src/routes/profile/components/ProfileStats.svelte
+++ b/src/routes/profile/components/ProfileStats.svelte
@@ -65,7 +65,7 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
-    border: 1px solid rgb(249, 158, 0);
+    border: 1px solid var(--ocean-color-cheese-yellow);
     padding: 20px;
   }
 

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -70,7 +70,7 @@
     max-width: 400px;
     margin: 100px auto;
     padding: 2rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--ocean-color-mist-light);
     border-radius: 4px;
   }
 

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -1,33 +1,38 @@
 @import '@fontsource/fira-mono';
+@import '$lib/ocean-palette.css';
 
 :root {
   --font-body:
     Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
     'Open Sans', 'Helvetica Neue', sans-serif;
   --font-mono: 'Fira Mono', monospace;
-  --color-text: rgba(0, 0, 0, 0.7);
   --column-width: 42rem;
   --column-margin-top: 4rem;
   font-family: var(--font-body);
-  color: var(--color-text);
-  --color-yellow: #ffb961;
-  --color-orange: #f3826f;
-  --color-pink: #c05c7e;
-  --color-purple: #722d61;
-  --color-blue: #2d3561;
-  --color-red: #f73859;
-  --color-text-secondary: #6b7280;
-  --color-text-tertiary: #888e99;
-  --color-affirmative-light: #f0fdfa;
-  --color-affirmative-dark: #0f766e;
-  --color-negative-light: #fff1f2;
-  --color-negative-dark: #be123c;
+
+  /* ─── Semantic color tokens → ocean palette ─── */
+  --color-text: var(--ocean-color-charcoal);
+  --color-yellow: var(--ocean-color-fe-yellow);
+  --color-orange: var(--ocean-color-tangerine);
+  --color-pink: var(--ocean-color-salmon);
+  --color-purple: var(--ocean-color-teal);
+  --color-blue: var(--ocean-color-navy);
+  --color-red: var(--ocean-color-red-sun);
+  --color-text-secondary: var(--ocean-color-mist);
+  --color-text-tertiary: var(--ocean-color-mist-light);
+  --color-affirmative-light: var(--ocean-color-pale-blue);
+  --color-affirmative-dark: var(--ocean-color-teal);
+  --color-negative-light: var(--ocean-color-pale-pink);
+  --color-negative-dark: var(--ocean-color-red-sun);
+  --color-border: var(--ocean-color-mist-30);
+
   --border-radius-md: 6px;
   --border-radius-lg: 8px;
   --card-border-radius: var(--border-radius-lg);
-  --color-border: rgba(10, 10, 10, 0.1);
   --page-content-max-width: 1216px;
   --page-content-padding: 32px;
+
+  color: var(--color-text);
 }
 
 html {

--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -1,0 +1,193 @@
+<svelte:head>
+  <title>Support — Frontend Challenge</title>
+  <meta
+    name="description"
+    content="Frontend Challenge is free to use. Learn how you can support the project by contributing code, sharing, or buying a coffee."
+  />
+  <script
+    type="text/javascript"
+    src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+    data-name="bmc-button"
+    data-slug="nealhorner"
+    data-color="#FFDD00"
+    data-emoji=""
+    data-font="Cookie"
+    data-text="Buy me a coffee"
+    data-outline-color="#000000"
+    data-font-color="#000000"
+    data-coffee-color="#ffffff"
+  ></script>
+</svelte:head>
+
+<div class="page">
+  <div class="inner">
+    <h1>Support Frontend Challenge</h1>
+    <p class="subtitle">
+      Frontend Challenge is completely free — no paywalls, no subscriptions. If you find it useful,
+      any support is genuinely appreciated.
+    </p>
+
+    <div class="ways">
+      <div class="way-card">
+        <div class="way-icon">&#128187;</div>
+        <h2>Contribute on GitHub</h2>
+        <p>
+          Found a bug? Have an idea for a new feature or question? Open an issue or submit a pull
+          request on GitHub.
+        </p>
+        <a
+          class="link-btn"
+          href="https://github.com/nealhorner/frontend-challenge"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View the Repository
+        </a>
+      </div>
+
+      <div class="way-card">
+        <div class="way-icon">&#128172;</div>
+        <h2>Share on Social Media</h2>
+        <p>
+          Tell your fellow developers about Frontend Challenge. Sharing the app helps the community
+          grow and keeps the project alive.
+        </p>
+        <div class="share-links">
+          <a
+            class="link-btn secondary"
+            href="https://twitter.com/intent/tweet?text=Check%20out%20Frontend%20Challenge%20%E2%80%94%20a%20free%20app%20to%20test%20your%20JavaScript%2C%20CSS%2C%20and%20React%20skills!%20https%3A%2F%2Fgithub.com%2Fnealhorner%2Ffrontend-challenge"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Share on X
+          </a>
+          <a
+            class="link-btn secondary"
+            href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2Fnealhorner%2Ffrontend-challenge"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Share on LinkedIn
+          </a>
+        </div>
+      </div>
+
+      <div class="way-card">
+        <div class="way-icon">&#9749;</div>
+        <h2>Buy Me a Coffee</h2>
+        <p>
+          If you'd like to say thanks with a small donation, I'd really appreciate it. Every coffee
+          helps keep the project running.
+        </p>
+        <a
+          href="https://www.buymeacoffee.com/nealhorner"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
+            alt="Buy Me a Coffee"
+            style="height: 60px !important; width: 217px !important;"
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .page {
+    padding: 56px var(--page-content-padding);
+    flex: 1;
+  }
+
+  .inner {
+    max-width: 860px;
+    margin: 0 auto;
+  }
+
+  h1 {
+    font-size: clamp(1.8rem, 5vw, 2.4rem);
+    font-weight: 500;
+    color: var(--color-blue);
+    margin: 0 0 16px;
+  }
+
+  .subtitle {
+    font-size: 1.05rem;
+    color: var(--color-text);
+    line-height: 1.6;
+    margin: 0 0 48px;
+    max-width: 600px;
+  }
+
+  .ways {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+  }
+
+  .way-card {
+    background: white;
+    border: 1px solid var(--color-border);
+    border-radius: var(--card-border-radius);
+    padding: 32px 28px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  }
+
+  .way-icon {
+    font-size: 2rem;
+    line-height: 1;
+  }
+
+  h2 {
+    font-size: 1.15rem;
+    font-weight: 500;
+    color: var(--color-purple);
+    margin: 0;
+  }
+
+  p {
+    color: var(--color-text);
+    line-height: 1.6;
+    margin: 0;
+    font-size: 0.95rem;
+    flex: 1;
+  }
+
+  .share-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .link-btn {
+    display: inline-block;
+    padding: 10px 18px;
+    background-color: var(--color-blue);
+    color: var(--color-yellow);
+    text-decoration: none;
+    border-radius: var(--border-radius-md);
+    font-size: 0.9rem;
+    transition: opacity 0.15s;
+  }
+
+  .link-btn:hover {
+    opacity: 0.85;
+  }
+
+  .link-btn.secondary {
+    background-color: var(--color-purple);
+    color: white;
+  }
+
+  @media (max-width: 600px) {
+    .page {
+      padding: 40px 20px;
+    }
+  }
+</style>

--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -66,11 +66,7 @@
           If you'd like to say thanks with a small donation, I'd really appreciate it. Every coffee
           helps keep the project running.
         </p>
-        <a
-          href="https://www.buymeacoffee.com/nealhorner"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://www.buymeacoffee.com/nealhorner" target="_blank" rel="noopener noreferrer">
           <img
             src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
             alt="Buy Me a Coffee"

--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -4,19 +4,6 @@
     name="description"
     content="Frontend Challenge is free to use. Learn how you can support the project by contributing code, sharing, or buying a coffee."
   />
-  <script
-    type="text/javascript"
-    src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
-    data-name="bmc-button"
-    data-slug="nealhorner"
-    data-color="#FFDD00"
-    data-emoji=""
-    data-font="Cookie"
-    data-text="Buy me a coffee"
-    data-outline-color="#000000"
-    data-font-color="#000000"
-    data-coffee-color="#ffffff"
-  ></script>
 </svelte:head>
 
 <div class="page">
@@ -87,6 +74,7 @@
           <img
             src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
             alt="Buy Me a Coffee"
+            loading="lazy"
             style="height: 60px !important; width: 217px !important;"
           />
         </a>


### PR DESCRIPTION
## Summary

- **Support page** (`/support`): three-panel page linking to the GitHub repo, social share buttons (X, LinkedIn), and a Buy Me a Coffee embed. Footer updated with a Support nav link.
- **Ocean palette** (`src/lib/ocean-palette.css`): 24 color tokens + 7 gradient tokens pulled from the ocean color palette, all prefixed `--ocean-*`.
- **Palette applied app-wide**: all `--color-*` semantic tokens in `styles.css` now reference ocean variables, so the change cascades through every component automatically. Individual hard-coded values patched in: `QuestionTag` tag color array, auth input borders, error red, `ProfileStats` border, `ProfileHeader` photo placeholder, `Card` shadow, `ResourceListing` text color.

## Visual changes

| Element | Before | After |
|---|---|---|
| Header / hero background | Dark blue `#2d3561` | Ocean navy `#1c4067` |
| H1 / nav links | Yellow `#ffb961` | FE yellow `#ffed4f` |
| H1 text shadow | Orange `#f3826f` | Tangerine `#f2973d` |
| Primary buttons | Purple `#722d61` | Teal `#008f98` |
| Value section background | Flat yellow | Cream → pale-yellow gradient |
| Final CTA band | Purple | Teal |
| Question tags | Plotly rainbow palette | Ocean accent colors |

## Reviewer notes

- `.claude/launch.json` added — tells the Claude Code preview tool how to start the dev server; safe to keep in the repo.
- `.claude/worktrees/` added to `.gitignore` — was previously unignored, though the directory was never committed.
- `.env` is **not** changed in this PR (it's gitignored). The `DATABASE_URL` fix from earlier in the session is a local-only change.

## Test plan

- [ ] Homepage hero, value section, and CTA render with ocean colors
- [ ] `/support` page loads and all three cards display correctly
- [ ] `/learn`, `/quiz`, `/login`, `/register`, `/profile` load without visual regressions
- [ ] Primary and secondary buttons render correctly on both light and dark backgrounds
- [ ] Question tags display in ocean palette colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)