### PR TITLE
Redesign Learn page with hero, filter tabs, and resource grid

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
 reviews:
   auto_review:
     auto_pause_after_reviewed_commits: 1
+  request_changes_workflow: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+reviews:
+  auto_review:
+    auto_pause_after_reviewed_commits: 1

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -8,16 +8,26 @@
   }
 
   let { data }: Props = $props();
-  let blogs = $derived(data.learning_resources.filter((resource) => resource.type === 'blog'));
-  let courses = $derived(data.learning_resources.filter((resource) => resource.type === 'course'));
-  let podcasts = $derived(
-    data.learning_resources.filter((resource) => resource.type === 'podcast')
+
+  type Filter = 'all' | 'blog' | 'course' | 'podcast';
+  let activeFilter = $state<Filter>('all');
+
+  let blogs = $derived(data.learning_resources.filter((r) => r.type === 'blog'));
+  let courses = $derived(data.learning_resources.filter((r) => r.type === 'course'));
+  let podcasts = $derived(data.learning_resources.filter((r) => r.type === 'podcast'));
+
+  let filtered = $derived(
+    activeFilter === 'all'
+      ? data.learning_resources
+      : data.learning_resources.filter((r) => r.type === activeFilter)
   );
 
-  // const sendEmail = () => {
-  //   const email = 'mailto:'; //FIXME: Add your email here
-  //   window.open(email);
-  // };
+  const filters: { label: string; value: Filter }[] = [
+    { label: 'All', value: 'all' },
+    { label: 'Blogs', value: 'blog' },
+    { label: 'Courses', value: 'course' },
+    { label: 'Podcasts', value: 'podcast' }
+  ];
 
   const faqItems = [
     {
@@ -37,88 +47,196 @@
 </script>
 
 <svelte:head>
-  <title>Frontend Challenge Learn</title>
-  <meta name="description" content="Learning resources for frontend developers" />
+  <title>Learning Resources — Frontend Challenge</title>
+  <meta name="description" content="Curated blogs, courses, and podcasts to level up your frontend skills." />
 </svelte:head>
 
-<main>
-  <h1>Learning Resources</h1>
+<div class="hero">
+  <div class="hero-inner">
+    <h1>Learning Resources</h1>
+    <p class="hero-sub">
+      Curated blogs, courses, and podcasts hand-picked to level up your frontend skills.
+    </p>
+    <div class="stats">
+      <span class="stat">{blogs.length} blogs</span>
+      <span class="divider">·</span>
+      <span class="stat">{courses.length} courses</span>
+      <span class="divider">·</span>
+      <span class="stat">{podcasts.length} podcasts</span>
+    </div>
+  </div>
+</div>
 
-  <p>
-    Here you can find a list of learning resources for frontend developers. Feel free to explore the
-    blogs, courses, and podcasts below. Enjoy!
-  </p>
-
-  <section>
-    <h2>Blogs</h2>
-
-    <ul>
-      {#each blogs as blog}
-        <li>
-          <ResourceListing
-            title={blog.title}
-            url={blog.url}
-            description={blog.description}
-            imageURL={blog.imageUrl}
-          />
-        </li>
+<div class="content">
+  <div class="content-inner">
+    <div class="filter-bar" role="tablist" aria-label="Filter resources">
+      {#each filters as f (f.value)}
+        <button
+          role="tab"
+          aria-selected={activeFilter === f.value}
+          class:active={activeFilter === f.value}
+          onclick={() => (activeFilter = f.value)}
+        >
+          {f.label}
+        </button>
       {/each}
-    </ul>
-  </section>
+    </div>
 
-  <section>
-    <h2>Courses</h2>
-    <ul>
-      {#each courses as course}
-        <li>
-          <ResourceListing
-            title={course.title}
-            url={course.url}
-            description={course.description}
-            imageURL={course.imageUrl}
-          />
-        </li>
+    {#if activeFilter === 'all'}
+      {#each [{ label: 'Blogs', type: 'blog', items: blogs }, { label: 'Courses', type: 'course', items: courses }, { label: 'Podcasts', type: 'podcast', items: podcasts }] as section (section.type)}
+        <section>
+          <h2>{section.label}</h2>
+          <ul class="resource-grid">
+            {#each section.items as resource (resource.url)}
+              <li>
+                <ResourceListing
+                  title={resource.title}
+                  url={resource.url}
+                  description={resource.description}
+                  imageURL={resource.imageUrl}
+                />
+              </li>
+            {/each}
+          </ul>
+        </section>
       {/each}
-    </ul>
-  </section>
+    {:else}
+      <ul class="resource-grid">
+        {#each filtered as resource (resource.url)}
+          <li>
+            <ResourceListing
+              title={resource.title}
+              url={resource.url}
+              description={resource.description}
+              imageURL={resource.imageUrl}
+            />
+          </li>
+        {/each}
+      </ul>
+    {/if}
 
-  <section>
-    <h2>Podcasts</h2>
-    <ul>
-      {#each podcasts as podcast}
-        <li>
-          <ResourceListing
-            title={podcast.title}
-            url={podcast.url}
-            description={podcast.description}
-            imageURL={podcast.imageUrl}
-          />
-        </li>
-      {/each}
-    </ul>
-  </section>
-  <section style="margin-top:40px">
-    <Faq {faqItems} />
-  </section>
-</main>
+    <section class="faq-section">
+      <Faq {faqItems} />
+    </section>
+  </div>
+</div>
 
 <style>
-  main {
-    max-width: 640px;
-    margin: 0 auto;
-    padding: 0px 10px;
+  .hero {
+    background-color: var(--color-blue);
+    padding: 56px var(--page-content-padding);
+    display: flex;
+    justify-content: center;
   }
-  h2 {
-    margin: 40px 0px 10px 0px;
-    color: var(--color-text-secondary);
+  .hero-inner {
+    max-width: var(--page-content-max-width);
+    width: 100%;
+    text-align: center;
   }
-  ul {
-    margin-top: 10px;
-    list-style: none;
-    padding: 0;
+  .hero h1 {
+    color: var(--color-yellow);
+    font-size: clamp(1.8rem, 5vw, 2.8rem);
+    font-weight: 500;
+    margin: 0 0 0.75rem;
+    text-shadow: 2px 2px var(--color-orange);
+    line-height: 1.15;
+  }
+  .hero-sub {
+    color: rgba(255, 255, 255, 0.88);
+    font-size: clamp(1rem, 2vw, 1.1rem);
+    line-height: 1.6;
+    margin: 0 auto 1.5rem;
+    max-width: 34rem;
+  }
+  .stats {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    color: var(--color-yellow);
+    font-size: 0.875rem;
+    opacity: 0.8;
+  }
+  .divider {
+    opacity: 0.5;
   }
 
-  li {
-    margin-bottom: 10px;
+  .content {
+    padding: 40px var(--page-content-padding) 64px;
+    display: flex;
+    justify-content: center;
+  }
+  .content-inner {
+    width: 100%;
+    max-width: var(--page-content-max-width);
+  }
+
+  .filter-bar {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 36px;
+  }
+  .filter-bar button {
+    padding: 7px 18px;
+    border-radius: 999px;
+    border: 1.5px solid var(--color-border);
+    background: white;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      border-color 0.15s,
+      color 0.15s;
+  }
+  .filter-bar button:hover {
+    border-color: var(--color-blue);
+    color: var(--color-blue);
+  }
+  .filter-bar button.active {
+    background-color: var(--color-blue);
+    border-color: var(--color-blue);
+    color: white;
+  }
+
+  section {
+    margin-bottom: 48px;
+  }
+  h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+    margin: 0 0 16px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .resource-grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 14px;
+  }
+
+  .faq-section {
+    margin-top: 16px;
+    border-top: 1px solid var(--color-border);
+    padding-top: 40px;
+  }
+
+  @media (max-width: 600px) {
+    .hero {
+      padding: 44px 20px;
+    }
+    .content {
+      padding: 28px 16px 48px;
+    }
+    .resource-grid {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -72,11 +72,10 @@
 
 <div class="content">
   <div class="content-inner">
-    <div class="filter-bar" role="tablist" aria-label="Filter resources">
+    <div class="filter-bar" aria-label="Filter resources">
       {#each filters as f (f.value)}
         <button
-          role="tab"
-          aria-selected={activeFilter === f.value}
+          aria-pressed={activeFilter === f.value}
           class:active={activeFilter === f.value}
           onclick={() => (activeFilter = f.value)}
         >

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -48,7 +48,10 @@
 
 <svelte:head>
   <title>Learning Resources — Frontend Challenge</title>
-  <meta name="description" content="Curated blogs, courses, and podcasts to level up your frontend skills." />
+  <meta
+    name="description"
+    content="Curated blogs, courses, and podcasts to level up your frontend skills."
+  />
 </svelte:head>
 
 <div class="hero">

--- a/src/routes/learn/components/ResourceListing.svelte
+++ b/src/routes/learn/components/ResourceListing.svelte
@@ -10,10 +10,11 @@
 
   let { title = '', url = '', description = '', imageURL = '' }: Props = $props();
 
-  let displayURL = $derived(url.replace(/(^\w+:|^)\/\//, '').replace(/\/$/, ''));
+  let safeURL = $derived(/^https?:\/\//i.test(url) ? url : '');
+  let displayURL = $derived(safeURL.replace(/(^\w+:|^)\/\//, '').replace(/\/$/, ''));
 </script>
 
-<a href={url} target="_blank" rel="noopener noreferrer" class="card-link">
+<a href={safeURL || '#'} target="_blank" rel="noopener noreferrer" class="card-link">
   <div class="card">
     <div class="resource-content">
       <h3>{title}</h3>

--- a/src/routes/learn/components/ResourceListing.svelte
+++ b/src/routes/learn/components/ResourceListing.svelte
@@ -21,8 +21,15 @@
         <p class="resource-description">{@html description}</p>
       {/if}
       <p class="link-text">
-        <svg class="link-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <path d="M3.5 3a.5.5 0 0 0 0 1H7.29L2.15 9.15a.5.5 0 1 0 .7.7L8 4.71V8.5a.5.5 0 0 0 1 0v-5a.5.5 0 0 0-.5-.5h-5z"/>
+        <svg
+          class="link-icon"
+          viewBox="0 0 12 12"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path
+            d="M3.5 3a.5.5 0 0 0 0 1H7.29L2.15 9.15a.5.5 0 1 0 .7.7L8 4.71V8.5a.5.5 0 0 0 1 0v-5a.5.5 0 0 0-.5-.5h-5z"
+          />
         </svg>
         {displayURL}
       </p>

--- a/src/routes/learn/components/ResourceListing.svelte
+++ b/src/routes/learn/components/ResourceListing.svelte
@@ -10,19 +10,22 @@
 
   let { title = '', url = '', description = '', imageURL = '' }: Props = $props();
 
-  // Remove the protocol from the URL and the trailing slash
   let displayURL = $derived(url.replace(/(^\w+:|^)\/\//, '').replace(/\/$/, ''));
 </script>
 
-<a href={url} target="_blank">
+<a href={url} target="_blank" rel="noopener noreferrer" class="card-link">
   <div class="card">
     <div class="resource-content">
       <h3>{title}</h3>
       {#if description}
         <p class="resource-description">{@html description}</p>
       {/if}
-      <p class="link-text">{displayURL}</p>
-      <!-- TODO make this line look like a link-->
+      <p class="link-text">
+        <svg class="link-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M3.5 3a.5.5 0 0 0 0 1H7.29L2.15 9.15a.5.5 0 1 0 .7.7L8 4.71V8.5a.5.5 0 0 0 1 0v-5a.5.5 0 0 0-.5-.5h-5z"/>
+        </svg>
+        {displayURL}
+      </p>
     </div>
     {#if imageURL}
       <div class="resource-image">
@@ -33,63 +36,119 @@
 </a>
 
 <style>
-  a {
+  .card-link {
     text-decoration: none;
     color: var(--ocean-color-charcoal);
+    display: block;
+    height: 100%;
   }
 
-  p.link-text:hover {
-    text-decoration: underline;
-    color: var(--color-blue);
-  }
-
-  div.card {
-    border: 1px solid rgba(0, 0, 0, 0.1);
+  .card {
+    border: 1px solid var(--color-border);
     border-radius: var(--card-border-radius);
     box-shadow:
-      0px 1px 2px -1px rgba(0, 0, 0, 0.1),
-      0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+      0px 1px 2px -1px rgba(0, 0, 0, 0.08),
+      0px 1px 3px 0px rgba(0, 0, 0, 0.06);
     color: var(--ocean-color-charcoal);
     background-color: var(--ocean-color-white);
     overflow: hidden;
     display: flex;
     align-items: stretch;
     width: 100%;
+    height: 100%;
+    transition:
+      box-shadow 0.15s ease,
+      border-color 0.15s ease;
   }
 
-  div.card:hover {
-    border: 1px solid rgba(0, 0, 0, 0.2);
+  .card:hover {
+    border-color: rgba(0, 0, 0, 0.18);
     box-shadow:
-      0px 1px 2px -1px rgba(0, 0, 0, 0.2),
-      0px 1px 3px 0px rgba(0, 0, 0, 0.2);
+      0px 4px 8px -2px rgba(0, 0, 0, 0.1),
+      0px 2px 4px 0px rgba(0, 0, 0, 0.06);
   }
 
-  div.resource-image {
-    width: 170px;
+  .resource-content {
+    flex-grow: 1;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--color-blue);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  p.resource-description {
+    font-size: 0.82rem;
+    color: var(--color-text-secondary);
+    line-height: 1.45;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  p.link-text {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.78rem;
+    color: var(--color-text-tertiary);
+    margin-top: auto;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .card:hover p.link-text {
+    color: var(--color-blue);
+  }
+
+  .link-icon {
+    width: 10px;
+    height: 10px;
+    fill: currentColor;
+    flex-shrink: 0;
+  }
+
+  .resource-image {
+    width: 120px;
     display: flex;
     flex-shrink: 0;
     position: relative;
   }
 
-  div.resource-image > div {
-    width: 170px;
+  .resource-image > div {
+    width: 100%;
     position: absolute;
     top: 0;
-    right: -10px;
+    right: 0;
     bottom: 0;
+    left: 0;
     background-size: cover;
-    background-position-y: center;
-    background-position-x: left;
+    background-position: center;
     background-repeat: no-repeat;
-    transition: all 0.2s ease-in-out;
+    transition: transform 0.2s ease-in-out;
   }
 
-  div.card:hover div.resource-image > div {
-    /* width: 150px; */
-    transform: scale(1.05) translateX(-5px);
+  .card:hover .resource-image > div {
+    transform: scale(1.05);
   }
 
-  div.resource-image > div::before {
+  .resource-image > div::before {
     content: '';
     position: absolute;
     top: 0;
@@ -98,27 +157,9 @@
     left: 0;
     background: linear-gradient(
       to right,
-      rgba(255, 255, 255, 0.1) 0%,
-      rgba(255, 255, 255, 0.1) 80%,
-      rgba(150, 150, 150, 0.5) 92%,
-      rgba(150, 150, 150, 0.9) 100%
+      rgba(255, 255, 255, 0.05) 0%,
+      rgba(255, 255, 255, 0) 60%,
+      rgba(200, 200, 200, 0.4) 100%
     );
-  }
-
-  div.resource-content {
-    flex-grow: 1;
-    padding: 10px;
-  }
-
-  h3 {
-    margin: 0;
-  }
-
-  p {
-    margin: 0;
-  }
-
-  p.resource-description {
-    font-size: smaller;
   }
 </style>


### PR DESCRIPTION
## Summary

- Adds a blue/yellow hero banner (matching the homepage design system) with a tagline and live resource counts
- Adds pill-style filter tabs — All / Blogs / Courses / Podcasts — with reactive client-side filtering via Svelte 5 `$state`
- Widens the layout from a 640 px single-column list to a full-width responsive grid (`auto-fill, minmax(300px, 1fr)`) that collapses to 1 column on mobile
- Refreshes resource cards: blue title, external-link arrow icon on the URL, 2-line description clamp, and smoother hover shadow

## Test plan

- [ ] Visit `/learn` — hero renders with blue background and yellow title, stat line shows correct counts
- [ ] Click each filter tab and confirm only the matching category appears; "All" view restores grouped sections (Blogs / Courses / Podcasts)
- [ ] Resize to mobile (≤ 600 px) — cards stack single-column, filter tabs wrap cleanly
- [ ] Hover a card — border darkens and link URL shifts to blue
- [ ] External links open in a new tab with `rel="noopener noreferrer"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering functionality to the learning resources page; users can now filter by resource type.
  * Added resource count displays and a new FAQ section to the learning page.

* **Style**
  * Enhanced resource card styling with improved layout, hover effects, and visual icons alongside links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->