### PR TITLE
Focus first input on quiz start and question change

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     }
   ]
 }

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import Button from './Button.svelte';
   import RadioGroup from './RadioGroup.svelte';
   import { QuestionType, type ParsedMultipleChoiceOptions, type Question } from '$lib/types';
 
   let answer = $state('');
   let questionPromise: Promise<Question> | undefined = $state();
+  let containerEl: HTMLElement | undefined;
 
   interface Props {
     questionId: string;
@@ -53,7 +54,10 @@
 
   $effect(() => {
     if (questionId) {
-      questionPromise = getQuestion(questionId);
+      questionPromise = getQuestion(questionId).then((q) => {
+        tick().then(() => containerEl?.querySelector<HTMLElement>('input')?.focus());
+        return q;
+      });
       answer = '';
     }
   });
@@ -64,7 +68,7 @@
   }
 </script>
 
-<main>
+<main bind:this={containerEl}>
   {#await questionPromise}
     <p>...waiting</p>
   {:then question}


### PR DESCRIPTION
## Summary

- When a quiz starts or advances to the next question, the first interactive input in the `Question` component is now automatically focused
- Uses Svelte's `tick()` to wait for the DOM to update after the question fetch resolves before calling `.focus()`
- Works for both question types: multiple-choice (focuses first radio button) and blind-answer (focuses the text input)

## What changed

**[`src/lib/components/Question.svelte`](src/lib/components/Question.svelte)**
- Import `tick` from `svelte`
- Add `containerEl` ref bound to the `<main>` element
- After the question fetch resolves, call `tick().then(() => containerEl?.querySelector('input')?.focus())` to focus the first input once the DOM is rendered

**[`.claude/launch.json`](.claude/launch.json)**
- Added `autoPort: true` so the worktree dev server doesn't conflict with the main project's server on port 5173

## Test plan

- [ ] Start a new quiz — first question's first input should be focused immediately
- [ ] Submit an answer and advance to the next question — new question's input should be focused automatically
- [ ] Verify both question types (multiple-choice radio, blind-answer text) receive focus correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Question form now automatically focuses the first input field after a new question loads, making it faster to continue without extra clicks.
* **Chores**
  * Updated the development launch configuration to automatically select an available port when the configured one is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->