### PR TITLE
Fix IDOR in quiz results detail loader

### DIFF
--- a/src/routes/quiz/results/[quizId]/+page.server.ts
+++ b/src/routes/quiz/results/[quizId]/+page.server.ts
@@ -1,12 +1,17 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import prisma from '$lib/prisma';
 import type { PageServerLoad } from './$types';
 
-export const load = (async ({ params }) => {
+export const load = (async ({ params, locals }) => {
+  if (!locals.user) {
+    redirect(302, '/');
+  }
+
   const quizResult = await prisma.quiz.findUnique({
     where: {
       id: params.quizId,
-      isCompleted: true
+      isCompleted: true,
+      userId: locals.user.id
     },
     include: {
       quizQuestions: {
@@ -18,7 +23,7 @@ export const load = (async ({ params }) => {
   });
 
   if (!quizResult) {
-    error(404, `Could not find quiz results for ${params.quizId}`);
+    error(404, 'Could not find quiz results');
   }
 
   return { quizResult };


### PR DESCRIPTION
## What changed

The `/quiz/results/[quizId]` server loader ([src/routes/quiz/results/[quizId]/+page.server.ts](src/routes/quiz/results/[quizId]/+page.server.ts)) now enforces authentication and ownership:

- **Auth guard** — redirects to `/` if there is no session (`locals.user`).
- **Ownership scoping** — adds `userId: locals.user.id` to the Prisma `where` clause so a quiz only resolves for its owner.
- **Non-leaky 404** — the error message no longer echoes the requested id, and an unowned quiz returns the same generic 404 as a missing one, so existence isn't disclosed.

## Why

The loader previously fetched a quiz by `id` + `isCompleted` with **no authentication or ownership check** — an IDOR (broken object-level authorization). Anyone holding a quiz id could read another user's private graded results (score, correct answers, and the taker's submitted answers) **without being logged in**.

Quiz ids are routinely placed in URLs — the results-list page links to `/quiz/results/${id}` and the quiz Prompter redirects there on completion — so ids leak via browser history on shared machines, `Referer` headers, copied/shared links, screenshots, and server logs. Given a leaked id, access was fully unauthenticated.

This was surfaced by a security review of the application and validated at confidence 8/10 (severity Medium).

## How it's fixed

The fix mirrors the secure pattern already used by the sibling list route ([src/routes/quiz/results/+page.server.ts](src/routes/quiz/results/+page.server.ts)), which gates on `locals.user` and scopes by `userId`. A request to `/quiz/results/<someone-else's-quiz-id>` now returns a generic 404 (or redirects to `/` when unauthenticated).

## Reviewer notes

- TypeScript narrows `locals.user` to non-null after the `redirect()` guard (SvelteKit's `redirect` returns `never`); `svelte-check` reports no errors on this file.
- The pre-commit hook ran lint, prettier, and the full Playwright suite (7/7 passing).
- Out of scope but related: `GET /api/question` returns the secret `answers` field unauthenticated (a separate answer-key disclosure found during the same review). Not addressed here — happy to follow up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quiz results are now restricted to authenticated users and only display results owned by the requesting user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->