### PR TITLE
Fix Sentry environment split: disable in dev, tag correctly in prod

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -4,8 +4,9 @@ import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 
 Sentry.init({
   dsn: PUBLIC_SENTRY_DSN,
+  enabled: import.meta.env.PROD,
+  environment: import.meta.env.MODE,
   tracesSampleRate: 1.0,
-  environment: process.env.NODE_ENV ?? 'production',
 
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,6 +9,8 @@ import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 
 Sentry.init({
   dsn: PUBLIC_SENTRY_DSN,
+  enabled: import.meta.env.PROD,
+  environment: import.meta.env.MODE,
   tracesSampleRate: 0.1
 
   // uncomment the line below to enable Spotlight (https://spotlightjs.com)


### PR DESCRIPTION
## Summary

- Added `enabled: import.meta.env.PROD` to both `hooks.server.ts` and `hooks.client.ts` so Sentry is completely silent during `vite dev` — no local dev errors will appear in Sentry
- Added `environment: import.meta.env.MODE` to both hooks so deployed events are tagged `production` (or whatever mode is set at build time)
- Replaced `process.env.NODE_ENV ?? 'production'` in the client hook with `import.meta.env.MODE` — the old form is a Node.js pattern that isn't reliable in browser code; `import.meta.env.MODE` is the correct Vite idiom and is replaced at build time

## Why

All Sentry issues were appearing as `production` because the server hook had no `environment` set (Sentry defaults to `production`) and the client hook used a Node-style env lookup that doesn't work reliably in the browser.

## Test plan

- [ ] Run `vite dev` and intentionally trigger an error — confirm nothing appears in Sentry
- [ ] Check that a production build still sends events tagged with `environment: production` in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated error tracking configuration so reporting is explicitly enabled only in production builds.
  * Adjusted the reported environment label to use the current build mode, improving the accuracy of environment-specific diagnostics and alerting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->