### PR TITLE
Remove debug console.log from quiz answer endpoint

### DIFF
--- a/src/routes/api/quiz/questions/+server.ts
+++ b/src/routes/api/quiz/questions/+server.ts
@@ -68,15 +68,6 @@ export const POST = async ({ request, locals }) => {
     isCorrect = correctAnswers.includes(userAnswer);
   }
 
-  console.log('isCorrect', {
-    isCorrect: isCorrect,
-    correctAnswers: correctAnswers,
-    userAnswer: userAnswer,
-    prompt: question.prompt,
-    type: question.type,
-    correctAnswersLength: correctAnswers.length
-  });
-
   // Save the user's answer, update QuizQuestion
   const savedAnswer = await prisma.quizQuestion.update({
     where: {
@@ -95,8 +86,6 @@ export const POST = async ({ request, locals }) => {
     where: { quizId, isAnswered: false }
   });
   const isCompleted = quizQuestions.length === 0;
-
-  console.log('isCompleted', isCompleted);
 
   // Update the Quiz
   if (isCompleted) {


### PR DESCRIPTION
## Summary
- Removes two `console.log` calls in `POST /api/quiz/questions` that logged the correct answers, the user's submitted answer, and the question prompt on every single quiz submission.
- Leftover debugging output; no behavior change.

## Test plan
- [x] Local e2e suite passes (`npm run test:e2e`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only cleanup on a quiz submission route; no auth, scoring, or data-path changes.
> 
> **Overview**
> Removes leftover **debug logging** from `POST /api/quiz/questions` that ran on every answer submission—one log around correctness evaluation (including correct answers, user answer, and prompt) and one when the quiz is marked complete.
> 
> **No request handling, validation, or persistence logic changes**; only less noisy server output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3a42447642b2dd7afccc544c51005417a4a6ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary server-side debug logging from quiz answer submission.
  * Quiz validation, scoring, completion handling, and response behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->