### PR TITLE
Fix race condition in quiz completion

### DIFF
--- a/src/routes/api/quiz/questions/+server.ts
+++ b/src/routes/api/quiz/questions/+server.ts
@@ -96,9 +96,13 @@ export const POST = async ({ request, locals }) => {
   });
   const isCompleted = quizQuestions.length === 0;
 
-  console.log('isCompleted', isCompleted);
-
-  // Update the Quiz
+  // Update the Quiz. Guard the update with `isCompleted: false` so that two
+  // concurrent submissions which both observe "no questions remaining" can't
+  // both win the not-completed -> completed transition: Postgres serializes
+  // the two UPDATEs on this row, and whichever runs second re-checks the
+  // predicate against the now-committed row and matches zero rows. Without
+  // this guard both requests would run postQuizTasksNonBlocking, double
+  // counting stats and Elo for a single quiz.
   if (isCompleted) {
     const quizWithQuestions = await prisma.quiz.findUniqueOrThrow({
       where: {
@@ -111,15 +115,17 @@ export const POST = async ({ request, locals }) => {
 
     // Calculate the score
     const score = quizWithQuestions.quizQuestions.filter((q) => q.isCorrect).length * 10;
-    await prisma.quiz.update({
-      where: { id: quizId },
+    const { count } = await prisma.quiz.updateMany({
+      where: { id: quizId, isCompleted: false },
       data: { isCompleted, score }
     });
 
-    // Perform post-quiz tasks
-    void postQuizTasksNonBlocking(quizWithQuestions).catch((error) => {
-      console.error('postQuizTasksNonBlocking failed', { quizId: quizWithQuestions.id, error });
-    });
+    // Only the request that actually flipped isCompleted runs post-quiz tasks.
+    if (count > 0) {
+      void postQuizTasksNonBlocking(quizWithQuestions).catch((error) => {
+        console.error('postQuizTasksNonBlocking failed', { quizId: quizWithQuestions.id, error });
+      });
+    }
   }
 
   return json(savedAnswer);


### PR DESCRIPTION
## Summary
- In `POST /api/quiz/questions`, the "is this the last question" check (`findMany` for unanswered questions) and the subsequent quiz-completion update weren't atomic. Two concurrent submissions (e.g. a double-click or a retried request) could both observe zero remaining unanswered questions and both run `postQuizTasksNonBlocking`, double-incrementing `UserStats` and double-applying Elo rating changes for a single quiz.
- Fix: guard the completion update with `isCompleted: false` via `updateMany` and only run post-quiz tasks when it actually matched a row (`count > 0`). Postgres serializes the two UPDATEs on the row; whichever runs second re-checks the predicate against the now-committed value and matches zero rows, so only one request wins the transition.

## Test plan
- [x] Local e2e suite passes (`npm run test:e2e`) — note the suite doesn't currently exercise the quiz-taking flow itself, so this change relies on the reasoning above plus manual review rather than a new automated race test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quiz completion and side effects (stats, Elo, streaks); the change is small and targeted but affects correctness of user-facing aggregates under concurrency.
> 
> **Overview**
> Fixes a race in **`POST /api/quiz/questions`** where two concurrent “last answer” requests could both treat the quiz as finished and run **`postQuizTasksNonBlocking`**, double-counting **`UserStats`** and applying Elo twice for one quiz.
> 
> Quiz completion now uses **`updateMany`** with **`where: { id: quizId, isCompleted: false }`** so only one request wins the not-completed → completed transition; **`postQuizTasksNonBlocking`** runs only when **`count > 0`**. A debug **`console.log`** for completion is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316187b787036e22570736d5233e6d8faba63949. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quiz completion handling when answers are submitted concurrently.
  * Prevented duplicate completion processing and related follow-up actions.
  * Ensured quiz completion is recorded only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->