### PR TITLE
Handle failed quiz answer submissions in the UI

### DIFF
--- a/src/routes/quiz/components/Prompter.svelte
+++ b/src/routes/quiz/components/Prompter.svelte
@@ -3,6 +3,7 @@
   import Card from '$lib/components/Card.svelte';
   import Question from '$lib/components/Question.svelte';
   import Progress from './Progress.svelte';
+  import ErrorMessage from '$lib/components/form/ErrorMessage.svelte';
   import type { QuizData } from '$lib/types';
   import { defaultQuizSize } from '$lib/constants';
   import DebugInfo from '$lib/components/DebugInfo.svelte';
@@ -32,18 +33,31 @@
   // Compute the number of completed questions from data.questions.length
   let completedQuestions = $state(getCompletedQuestionsCount());
   let totalQuestions = quizData.quizQuestions.length ?? defaultQuizSize;
+  let submitError: string | undefined = $state();
 
   async function handleQuestionSubmit(answer: string) {
-    // Update database record
-    await fetch('/api/quiz/questions', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        quizId: quizData.id,
-        questionId: currentQuestionId,
-        userAnswer: answer
-      })
-    });
+    submitError = undefined;
+
+    let response: Response;
+    try {
+      response = await fetch('/api/quiz/questions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          quizId: quizData.id,
+          questionId: currentQuestionId,
+          userAnswer: answer
+        })
+      });
+    } catch {
+      submitError = 'Failed to submit your answer. Check your connection and try again.';
+      return;
+    }
+
+    if (!response.ok) {
+      submitError = 'Failed to submit your answer. Please try again.';
+      return;
+    }
 
     // Update local object
     quizData.quizQuestions = quizData.quizQuestions.map((question) => {
@@ -69,6 +83,9 @@
   {:else if currentQuestionId}
     <DebugInfo>Question ID: {currentQuestionId}</DebugInfo>
     <Question questionId={currentQuestionId} submitHandler={handleQuestionSubmit} />
+    {#if submitError}
+      <ErrorMessage errorMessage={submitError} />
+    {/if}
   {/if}
   <Progress {completedQuestions} {totalQuestions} />
 </Card>

--- a/src/routes/quiz/components/Prompter.svelte
+++ b/src/routes/quiz/components/Prompter.svelte
@@ -34,45 +34,56 @@
   let completedQuestions = $state(getCompletedQuestionsCount());
   let totalQuestions = quizData.quizQuestions.length ?? defaultQuizSize;
   let submitError: string | undefined = $state();
+  // Guards against double-clicks/retries firing a second submit while one is
+  // still in flight — without this, a late-arriving response (e.g. a 400 for
+  // the now-already-answered question) could set submitError after an
+  // earlier, successful request already advanced the quiz.
+  let isSubmitting = false;
 
   async function handleQuestionSubmit(answer: string) {
+    if (isSubmitting) return;
+    isSubmitting = true;
     submitError = undefined;
 
-    let response: Response;
     try {
-      response = await fetch('/api/quiz/questions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          quizId: quizData.id,
-          questionId: currentQuestionId,
-          userAnswer: answer
-        })
-      });
-    } catch {
-      submitError = 'Failed to submit your answer. Check your connection and try again.';
-      return;
-    }
-
-    if (!response.ok) {
-      submitError = 'Failed to submit your answer. Please try again.';
-      return;
-    }
-
-    // Update local object
-    quizData.quizQuestions = quizData.quizQuestions.map((question) => {
-      if (question.questionId === currentQuestionId) {
-        question.isAnswered = true;
+      let response: Response;
+      try {
+        response = await fetch('/api/quiz/questions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            quizId: quizData.id,
+            questionId: currentQuestionId,
+            userAnswer: answer
+          })
+        });
+      } catch {
+        submitError = 'Failed to submit your answer. Check your connection and try again.';
+        return;
       }
-      return question;
-    });
 
-    currentQuestionId = getNextQuestionId();
-    completedQuestions = getCompletedQuestionsCount();
+      if (!response.ok) {
+        submitError = 'Failed to submit your answer. Please try again.';
+        return;
+      }
 
-    if (completedQuestions === totalQuestions) {
-      quizData.isCompleted = true;
-      goto(`/quiz/results/${quizData.id}`);
+      // Update local object
+      quizData.quizQuestions = quizData.quizQuestions.map((question) => {
+        if (question.questionId === currentQuestionId) {
+          question.isAnswered = true;
+        }
+        return question;
+      });
+
+      currentQuestionId = getNextQuestionId();
+      completedQuestions = getCompletedQuestionsCount();
+
+      if (completedQuestions === totalQuestions) {
+        quizData.isCompleted = true;
+        goto(`/quiz/results/${quizData.id}`);
+      }
+    } finally {
+      isSubmitting = false;
     }
   }
 </script>
@@ -84,7 +95,9 @@
     <DebugInfo>Question ID: {currentQuestionId}</DebugInfo>
     <Question questionId={currentQuestionId} submitHandler={handleQuestionSubmit} />
     {#if submitError}
-      <ErrorMessage errorMessage={submitError} />
+      <div role="alert">
+        <ErrorMessage errorMessage={submitError} />
+      </div>
     {/if}
   {/if}
   <Progress {completedQuestions} {totalQuestions} />


### PR DESCRIPTION
## Summary
- `handleQuestionSubmit` in `Prompter.svelte` never checked the response from `POST /api/quiz/questions`. If that request failed (expired session, 500, network blip), the client still marked the question answered locally and advanced to the next one.
- On the last question this meant `goto('/quiz/results/[id]')` even though the server never actually recorded completion, so the results page 404s (`quiz/results/[quizId]/+page.server.ts` requires `isCompleted: true`).
- Now checks `response.ok` (and catches network errors) before advancing local state, and shows a visible error via the existing `ErrorMessage` component so the user knows to retry instead of silently losing an answer.

## Test plan
- [x] Local e2e suite passes (`npm run test:e2e`)
- [x] `svelte-check` passes for the changed file (pre-existing unrelated errors in `profile/+page.svelte` only)
- [ ] Manual verification in a live browser wasn't possible in this environment — this worktree's Vite dev server can't serve SvelteKit's client entry (`fs.allow` blocks the shared `node_modules` path from this nested worktree checkout), so the page never hydrates client-side here. Reasoning and the checks above are the basis for confidence; worth a manual click-through in a normal checkout before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side error handling and UI feedback only; no changes to API, auth, or persistence logic.
> 
> **Overview**
> **Quiz answer submission** in `Prompter.svelte` now treats `POST /api/quiz/questions` failures as real failures instead of success.
> 
> `handleQuestionSubmit` clears a prior error, awaits the fetch inside **try/catch** (network errors get a connection-oriented message), and **returns early** when `!response.ok` with a retry message. Local state—marking the question answered, advancing `currentQuestionId`, bumping progress, setting `isCompleted`, and `goto` to results—runs **only after** a successful response.
> 
> Failed submits show the existing **`ErrorMessage`** component under the current question so users can retry without silently skipping answers or navigating to results when the server never recorded completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecbc6725ab7b3cac363cacf4940950c0db9d66e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a visible error message when quiz answer submissions fail due to network issues or server errors.
  * Prevented the quiz from continuing to process responses after an unsuccessful submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->