### PR TITLE
Avoid duplicate question fetch during quiz

### DIFF
--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -41,10 +41,14 @@
 
   interface Props {
     questionId: string;
+    // Preloaded question data (e.g. from a parent that already fetched the
+    // whole quiz). When it matches questionId, skip the network round trip
+    // in getQuestion below.
+    question?: Omit<Question, 'answers'>;
     submitHandler: (answer: string) => void;
   }
 
-  let { questionId = $bindable(), submitHandler }: Props = $props();
+  let { questionId = $bindable(), question: preloadedQuestion, submitHandler }: Props = $props();
 
   onMount(async () => {
     if (!questionId) {
@@ -84,13 +88,18 @@
   };
 
   $effect(() => {
-    if (questionId) {
-      questionPromise = getQuestion(questionId).then((q) => {
-        tick().then(() => containerEl?.querySelector<HTMLElement>('input')?.focus());
-        return q;
-      });
-      answer = '';
-    }
+    if (!questionId) return;
+
+    const source =
+      preloadedQuestion?.id === questionId
+        ? Promise.resolve(preloadedQuestion)
+        : getQuestion(questionId);
+
+    questionPromise = source.then((q) => {
+      tick().then(() => containerEl?.querySelector<HTMLElement>('input')?.focus());
+      return q;
+    });
+    answer = '';
   });
 
   function handleAnswerChange(event: Event) {

--- a/src/lib/components/Question.svelte
+++ b/src/lib/components/Question.svelte
@@ -5,7 +5,7 @@
   import { QuestionType, type ParsedMultipleChoiceOptions, type Question } from '$lib/types';
 
   let answer = $state('');
-  let questionPromise: Promise<Question> | undefined = $state();
+  let questionPromise: Promise<Omit<Question, 'answers'>> | undefined = $state();
   let containerEl: HTMLElement | undefined;
   let flagOpen = $state(false);
   let flagMessage = $state('');
@@ -66,7 +66,7 @@
     }
   }
 
-  async function getQuestion(questionId: string) {
+  async function getQuestion(questionId: string): Promise<Omit<Question, 'answers'>> {
     const response = await fetch(`/api/question/${questionId}`);
     const data = await response.json();
     if (response.ok) {

--- a/src/routes/quiz/components/Prompter.svelte
+++ b/src/routes/quiz/components/Prompter.svelte
@@ -14,6 +14,11 @@
   let { quizData = $bindable() }: Props = $props();
 
   let currentQuestionId: string | undefined = $state(getNextQuestionId());
+  // The quiz load already fetched every question in full, so hand the current
+  // one straight to <Question> instead of making it re-fetch over the network.
+  let currentQuestion = $derived(
+    quizData.quizQuestions.find((q) => q.questionId === currentQuestionId)?.question
+  );
 
   function getNextQuestionId() {
     return (
@@ -68,7 +73,11 @@
     <p>Finished Quiz</p>
   {:else if currentQuestionId}
     <DebugInfo>Question ID: {currentQuestionId}</DebugInfo>
-    <Question questionId={currentQuestionId} submitHandler={handleQuestionSubmit} />
+    <Question
+      questionId={currentQuestionId}
+      question={currentQuestion}
+      submitHandler={handleQuestionSubmit}
+    />
   {/if}
   <Progress {completedQuestions} {totalQuestions} />
 </Card>


### PR DESCRIPTION
## Summary
- `Prompter.svelte` already has every question's full data from the quiz load (`quizData.quizQuestions[].question`), but only passed `questionId` down to `<Question>`, which then re-fetched the same data over the network via `/api/question/[id]` on every single question — an extra DB round trip plus a visible "...waiting" flicker per question.
- `<Question>` now accepts an optional preloaded `question` prop; when it matches the current `questionId` it's used directly instead of fetching.
- The homepage "try a question" widget (`+page.svelte`), which has no preloaded data, is unaffected and still fetches as before.

## Test plan
- [x] Local e2e suite passes (`npm run test:e2e`)
- [x] `svelte-check` passes for changed files (pre-existing unrelated errors in `profile/+page.svelte` only)
- [ ] Manual click-through wasn't possible in this environment — this worktree's Vite dev server can't serve SvelteKit's client entry (`fs.allow` blocks the shared `node_modules` path from this nested worktree checkout), so pages never hydrate client-side here. Worth a manual run-through in a normal checkout before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional prop with id-match guard; fetch fallback unchanged for non-quiz usage.
> 
> **Overview**
> **During a quiz, each step no longer re-fetches question content that was already loaded with the quiz.**
> 
> `Question` gains an optional `question` prop. When its `id` matches `questionId`, the component resolves that object locally instead of calling `/api/question/[id]`, which should remove per-question network/DB work and the brief `...waiting` state.
> 
> `Prompter` derives the active question from `quizData.quizQuestions` and passes it into `Question`. Call sites that only have an id (e.g. the homepage try-a-question flow) keep the existing fetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7e546d94a4e6cb0c75352cbc01231d085cc9af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Quiz questions can now load from data already available in the quiz, reducing unnecessary requests.
  * Question displays remain synchronized with the active quiz question.
* **Bug Fixes**
  * Answer selections are reset correctly when the displayed question changes.
  * Existing input focus behavior is preserved when questions load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->