### PR TITLE
Fix wasteful query in /api/question

### DIFF
--- a/src/routes/api/question/+server.ts
+++ b/src/routes/api/question/+server.ts
@@ -1,19 +1,30 @@
 import { json } from '@sveltejs/kit';
 import prisma from '$lib/prisma';
 
+async function getRandomQuestion() {
+  const count = await prisma.question.count();
+  if (count === 0) return null;
+
+  // orderBy makes the random offset meaningful — without a defined order,
+  // the database is free to return rows in any sequence, so `skip` wouldn't
+  // reliably land on a well-distributed random row.
+  const [question] = await prisma.question.findMany({
+    orderBy: { id: 'asc' },
+    take: 1,
+    skip: Math.floor(Math.random() * count)
+  });
+
+  return question ?? null;
+}
+
 export async function GET() {
   // TODO implement this endpoint for global use outside of active quizzes
   // Get a random question from the database
 
-  const count = await prisma.question.count();
-  if (count === 0) {
-    return json({ error: 'Question not found' }, { status: 404 });
-  }
-
-  const [question] = await prisma.question.findMany({
-    take: 1,
-    skip: Math.floor(Math.random() * count)
-  });
+  // count() and findMany() aren't in a transaction, so a row deleted in
+  // between could make the offset land past the new end. Retry once with a
+  // fresh count before concluding there's truly nothing to return.
+  const question = (await getRandomQuestion()) ?? (await getRandomQuestion());
 
   if (!question) {
     return json({ error: 'Question not found' }, { status: 404 });

--- a/src/routes/api/question/+server.ts
+++ b/src/routes/api/question/+server.ts
@@ -1,18 +1,19 @@
 import { json } from '@sveltejs/kit';
 import prisma from '$lib/prisma';
-import { defaultQuizSize } from '$lib/constants';
 
 export async function GET() {
   // TODO implement this endpoint for global use outside of active quizzes
   // Get a random question from the database
 
-  const questions = await prisma.question.findMany({
-    take: defaultQuizSize
-    // TODO improve randomization
-  });
+  const count = await prisma.question.count();
+  if (count === 0) {
+    return json({ error: 'Question not found' }, { status: 404 });
+  }
 
-  const randomIndex = Math.floor(Math.random() * questions.length);
-  const question = questions[randomIndex];
+  const [question] = await prisma.question.findMany({
+    take: 1,
+    skip: Math.floor(Math.random() * count)
+  });
 
   if (!question) {
     return json({ error: 'Question not found' }, { status: 404 });


### PR DESCRIPTION
## Summary
- `GET /api/question` fetched `defaultQuizSize` (10) full question rows just to pick one at random and discard the other nine.
- Now gets the row count and does a random `OFFSET`/`LIMIT 1`, so exactly one row is read from the database and sent over the wire.

## Test plan
- [x] Local e2e suite passes (`npm run test:e2e`)
- [x] `svelte-check` passes for the changed file (pre-existing unrelated errors in `profile/+page.svelte` only)
- [x] Manually hit `curl http://localhost:5173/api/question` twice locally and confirmed it returns a valid, differing question each time

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small query-shape change on a read-only endpoint; behavior stays one random question or 404, with slightly different randomness distribution via OFFSET.
> 
> **Overview**
> `GET /api/question` no longer loads **`defaultQuizSize` (10) full question rows** only to pick one in application code. It now **`count()`s** questions, returns **404** when the table is empty, then loads **exactly one** row with **`take: 1`** and **`skip: Math.floor(Math.random() * count)`**.
> 
> The **`defaultQuizSize`** import from **`$lib/constants`** is removed from this handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f6e7abfcfadb062ca338d0006069cfe6877c3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved random question selection for more varied results.
  * Added a clear not-found response when no questions are available.
  * Preserved the existing API response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->